### PR TITLE
Use azure partitions

### DIFF
--- a/main.go
+++ b/main.go
@@ -351,7 +351,7 @@ func (deps *AppHandlers) GetHandler(w http.ResponseWriter, r *http.Request, ps h
 }
 
 func (deps *AppHandlers) TimeBackendGet(uuid string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 500 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 	deps.Metrics.getsBackend.Request.Mark(1)
 	ts := time.Now()
@@ -367,7 +367,7 @@ func (deps *AppHandlers) TimeBackendGet(uuid string) (string, error) {
 
 func (deps *AppHandlers) TimeBackendPut(key string, value string) error {
 	var err error
-	ctx, cancel := context.WithTimeout(context.Background(), 500 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 	deps.Metrics.putsBackend.Request.Mark(1)
 	deps.Metrics.putsBackend.Duration.Time(func() {

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/julienschmidt/httprouter"
-	"regexp"
 	"sync"
 )
 
@@ -224,26 +223,5 @@ func TestGetInvalidUUID(t *testing.T) {
 	if getResults.Code != http.StatusNotFound {
 		t.Fatalf("Expected GET to return 404 on unrecognized ID. Got: %d", getResults.Code)
 		return
-	}
-}
-
-func TestUUIDGeneration(t *testing.T) {
-	// Stolen from https://stackoverflow.com/questions/25051675/how-to-validate-uuid-v4-in-go
-	regex := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89aAbB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
-
-	resp := PutResponse{
-		Responses: make([]PutResponseObject, 20),
-	}
-	resp.populateUUIDs()
-
-	fixedChars := resp.Responses[0].UUID[0:4]
-	for i := 0; i < len(resp.Responses); i++ {
-		thisId := resp.Responses[i].UUID
-		if fixedChars != thisId[0:4] {
-			t.Errorf("UUIDs %s and %s do not share the same first 16 bytes.", resp.Responses[0].UUID, thisId)
-		}
-		if !regex.MatchString(thisId) {
-			t.Errorf("%s is not a valid UUID", thisId)
-		}
 	}
 }


### PR DESCRIPTION
Azure requires a partition key for higher throughput. This pulls the first 4 characters (16 out of the 122 bits of UUID-randomness) for a partition key.

Someday, we should also write a stored procedure in Azure to allow batch uploads, to minimize the number of requests. Azure only lets stored procedures interact with a single partition... so this also constrains the generated UUIDs so that those first 4 characters are shared across all items in a single request.