### PR TITLE
Added health check endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -390,6 +390,12 @@ func (deps *AppHandlers) sendError(w http.ResponseWriter, err string, status int
 	w.Write([]byte(err))
 }
 
+func status(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	// We might want more logic here eventually... but for now, we're ok to serve more traffic as
+	// long as the server responds.
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func parseUUID(r *http.Request) string {
 	return r.URL.Query().Get("uuid")
 }
@@ -470,6 +476,7 @@ func main() {
 	router := httprouter.New()
 	router.POST("/put", appHandlers.PutHandler)
 	router.GET("/get", appHandlers.GetHandler)
+	router.GET("/status", status) // Determines whether the server is ready for more traffic.
 
 	router.POST("/cache", appHandlers.PutCacheHandler)
 	router.GET("/cache", appHandlers.GetCacheHandler)

--- a/main_test.go
+++ b/main_test.go
@@ -225,3 +225,16 @@ func TestGetInvalidUUID(t *testing.T) {
 		return
 	}
 }
+
+func TestReadinessCheck(t *testing.T) {
+	requestRecorder := httptest.NewRecorder()
+
+	router := httprouter.New()
+	router.GET("/status", status)
+	req, _ := http.NewRequest("GET", "/status", new(bytes.Buffer))
+	router.ServeHTTP(requestRecorder, req)
+
+	if requestRecorder.Code != http.StatusNoContent {
+		t.Errorf("/status endpoint should always return a 204. Got %d", requestRecorder.Code)
+	}
+}


### PR DESCRIPTION
Needed to define Kubernetes [readiness/liveliness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-liveness-http-request)