### PR TITLE
Log metrics per format

### DIFF
--- a/backends/constants.go
+++ b/backends/constants.go
@@ -1,0 +1,7 @@
+package backends
+
+// These strings are prefixed onto data put in the backend, to designate its type.
+const (
+	XML_PREFIX  = "xml"
+	JSON_PREFIX = "json"
+)

--- a/endpoints/constants.go
+++ b/endpoints/constants.go
@@ -1,11 +1,6 @@
 package endpoints
 
 const (
-	XML_PREFIX  = "xml"
-	JSON_PREFIX = "json"
-)
-
-const (
 	MaxValueLength = 1024 * 10
 	MaxNumValues   = 10
 )

--- a/endpoints/get.go
+++ b/endpoints/get.go
@@ -31,12 +31,12 @@ func NewGetHandler(backend backends.Backend) func(http.ResponseWriter, *http.Req
 			return
 		}
 
-		if strings.HasPrefix(value, XML_PREFIX) {
+		if strings.HasPrefix(value, backends.XML_PREFIX) {
 			w.Header().Set("Content-Type", "application/xml")
-			w.Write([]byte(value)[len(XML_PREFIX):])
-		} else if strings.HasPrefix(value, JSON_PREFIX) {
+			w.Write([]byte(value)[len(backends.XML_PREFIX):])
+		} else if strings.HasPrefix(value, backends.JSON_PREFIX) {
 			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(value)[len(JSON_PREFIX):])
+			w.Write([]byte(value)[len(backends.JSON_PREFIX):])
 		} else {
 			http.Error(w, "Cache data was corrupted. Cannot determine type.", http.StatusInternalServerError)
 		}

--- a/endpoints/put.go
+++ b/endpoints/put.go
@@ -67,7 +67,7 @@ func NewPutHandler(backend backends.Backend) func(http.ResponseWriter, *http.Req
 			}
 
 			var toCache string
-			if p.Type == XML_PREFIX {
+			if p.Type == backends.XML_PREFIX {
 				if p.Value[0] != byte('"') || p.Value[len(p.Value)-1] != byte('"') {
 					http.Error(w, fmt.Sprintf("XML messages must have a String value. Found %v", p.Value), http.StatusBadRequest)
 					return
@@ -78,7 +78,7 @@ func NewPutHandler(backend backends.Backend) func(http.ResponseWriter, *http.Req
 				var interpreted string
 				json.Unmarshal(p.Value, &interpreted)
 				toCache = p.Type + interpreted
-			} else if p.Type == JSON_PREFIX {
+			} else if p.Type == backends.JSON_PREFIX {
 				toCache = p.Type + string(p.Value)
 			} else {
 				http.Error(w, fmt.Sprintf("Type must be one of [\"json\", \"xml\"]. Found %v", p.Type), http.StatusBadRequest)

--- a/metrics/core.go
+++ b/metrics/core.go
@@ -9,28 +9,46 @@ import (
 )
 
 type MetricsEntry struct {
-	Request    metrics.Meter
 	Duration   metrics.Timer
 	Errors     metrics.Meter
 	BadRequest metrics.Meter
+	Request    metrics.Meter
+}
+
+type MetricsEntryByFormat struct {
+	Duration       metrics.Timer
+	Errors         metrics.Meter
+	BadRequest     metrics.Meter
+	JsonRequest    metrics.Meter
+	XmlRequest     metrics.Meter
+	InvalidRequest metrics.Meter
 }
 
 func NewMetricsEntry(name string, r metrics.Registry) *MetricsEntry {
-	me := &MetricsEntry{
-		Request:    metrics.GetOrRegisterMeter(fmt.Sprintf("%s.request_count", name), r),
+	return &MetricsEntry{
 		Duration:   metrics.GetOrRegisterTimer(fmt.Sprintf("%s.request_duration", name), r),
 		Errors:     metrics.GetOrRegisterMeter(fmt.Sprintf("%s.error_count", name), r),
 		BadRequest: metrics.GetOrRegisterMeter(fmt.Sprintf("%s.bad_request_count", name), r),
+		Request:    metrics.GetOrRegisterMeter(fmt.Sprintf("%s.request_count", name), r),
 	}
+}
 
-	return me
+func NewMetricsEntryByType(name string, r metrics.Registry) *MetricsEntryByFormat {
+	return &MetricsEntryByFormat{
+		Duration:       metrics.GetOrRegisterTimer(fmt.Sprintf("%s.request_duration", name), r),
+		Errors:         metrics.GetOrRegisterMeter(fmt.Sprintf("%s.error_count", name), r),
+		BadRequest:     metrics.GetOrRegisterMeter(fmt.Sprintf("%s.bad_request_count", name), r),
+		JsonRequest:    metrics.GetOrRegisterMeter(fmt.Sprintf("%s.json_request_count", name), r),
+		XmlRequest:     metrics.GetOrRegisterMeter(fmt.Sprintf("%s.xml_request_count", name), r),
+		InvalidRequest: metrics.GetOrRegisterMeter(fmt.Sprintf("%s.unknown_request_count", name), r),
+	}
 }
 
 type Metrics struct {
 	Registry    metrics.Registry
 	Puts        *MetricsEntry
 	Gets        *MetricsEntry
-	PutsBackend *MetricsEntry
+	PutsBackend *MetricsEntryByFormat
 	GetsBackend *MetricsEntry
 }
 
@@ -54,7 +72,7 @@ func CreateMetrics() *Metrics {
 		Registry:    r,
 		Puts:        NewMetricsEntry("puts.current_url", r),
 		Gets:        NewMetricsEntry("gets.current_url", r),
-		PutsBackend: NewMetricsEntry("puts.backend", r),
+		PutsBackend: NewMetricsEntryByType("puts.backend", r),
 		GetsBackend: NewMetricsEntry("gets.backend", r),
 	}
 


### PR DESCRIPTION
Our product manager requested that we take metrics for `json` vs. `xml` payloads separately. I don't think this will cause rubicon any trouble, because influx (the only supported export at the moment) lets you combine them with a regex-query... but let me know if I'm wrong there.