### PR TITLE
Fixed a small bug in the aerospike client

### DIFF
--- a/backends/aerospike.go
+++ b/backends/aerospike.go
@@ -2,8 +2,10 @@ package backends
 
 import (
 	"context"
-	as "github.com/aerospike/aerospike-client-go"
+	"errors"
+
 	log "github.com/Sirupsen/logrus"
+	as "github.com/aerospike/aerospike-client-go"
 )
 
 type AerospikeConfig struct {
@@ -35,9 +37,12 @@ func (a *Aerospike) Get(ctx context.Context, key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	rec, err := a.client.Get(nil, asKey)
+	rec, err := a.client.Get(nil, asKey, "value")
 	if err != nil {
 		return "", err
+	}
+	if rec == nil {
+		return "", errors.New("client.Get returned a nil record. Is aerospike configured properly?")
 	}
 	return rec.Bins["value"].(string), nil
 }

--- a/backends/aerospike.go
+++ b/backends/aerospike.go
@@ -8,6 +8,9 @@ import (
 	as "github.com/aerospike/aerospike-client-go"
 )
 
+const setName = "uuid"
+const binValue = "value"
+
 type AerospikeConfig struct {
 	host      string
 	port      int
@@ -33,7 +36,7 @@ func NewAerospikeBackend(config *AerospikeConfig) (*Aerospike, error) {
 }
 
 func (a *Aerospike) Get(ctx context.Context, key string) (string, error) {
-	asKey, err := as.NewKey(a.config.namespace, "uuid", key)
+	asKey, err := as.NewKey(a.config.namespace, setName, key)
 	if err != nil {
 		return "", err
 	}
@@ -44,16 +47,16 @@ func (a *Aerospike) Get(ctx context.Context, key string) (string, error) {
 	if rec == nil {
 		return "", errors.New("client.Get returned a nil record. Is aerospike configured properly?")
 	}
-	return rec.Bins["value"].(string), nil
+	return rec.Bins[binValue].(string), nil
 }
 
 func (a *Aerospike) Put(ctx context.Context, key string, value string) error {
-	asKey, err := as.NewKey(a.config.namespace, "uuid", key)
+	asKey, err := as.NewKey(a.config.namespace, setName, key)
 	if err != nil {
 		return err
 	}
 	bins := as.BinMap{
-		"value": value,
+		binValue: value,
 	}
 	err = a.client.Put(nil, asKey, bins)
 	if err != nil {


### PR DESCRIPTION
If the aerospike cluster is misconfigured, the client here will return `nil, nil`. This causes the app to crash on `rec.Bins["value"].(string)`

This makes it a bit more robust, and should make read times more efficient too (if, for example, the same namespace was used for multi-bin values in other apps)