### PR TITLE
More payload metrics

### DIFF
--- a/backends/decorators/size_limit.go
+++ b/backends/decorators/size_limit.go
@@ -1,0 +1,47 @@
+package decorators
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/prebid/prebid-cache/backends"
+)
+
+// EnforceSizeLimit rejects payloads over a max size.
+// If a payload is too large, the Put() function will return a BadPayloadSize error.
+func EnforceSizeLimit(delegate backends.Backend, maxSize int) backends.Backend {
+	return &sizeCappedBackend{
+		delegate: delegate,
+		limit:    maxSize,
+	}
+}
+
+type sizeCappedBackend struct {
+	delegate backends.Backend
+	limit    int
+}
+
+func (b *sizeCappedBackend) Get(ctx context.Context, key string) (string, error) {
+	return b.delegate.Get(ctx, key)
+}
+
+func (b *sizeCappedBackend) Put(ctx context.Context, key string, value string) error {
+	valueLen := len(value)
+	if valueLen == 0 || valueLen > b.limit {
+		return &BadPayloadSize{
+			limit: b.limit,
+			size:  valueLen,
+		}
+	}
+
+	return b.delegate.Put(ctx, key, value)
+}
+
+type BadPayloadSize struct {
+	limit int
+	size  int
+}
+
+func (p *BadPayloadSize) Error() string {
+	return "Payload size " + strconv.Itoa(p.size) + " exceeded max " + strconv.Itoa(p.limit)
+}

--- a/backends/decorators/size_limit_test.go
+++ b/backends/decorators/size_limit_test.go
@@ -1,0 +1,47 @@
+package decorators
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLargePayload(t *testing.T) {
+	delegate := &successfulBackend{}
+	wrapped := EnforceSizeLimit(delegate, 5)
+	assertBadPayloadError(t, wrapped.Put(context.Background(), "foo", "123456"))
+}
+
+func TestAcceptablePayload(t *testing.T) {
+	delegate := &successfulBackend{}
+	wrapped := EnforceSizeLimit(delegate, 5)
+	assertNilError(t, wrapped.Put(context.Background(), "foo", "12345"))
+}
+
+func assertBadPayloadError(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Errorf("Expected an error, but got none.")
+	}
+	if _, ok := err.(*BadPayloadSize); !ok {
+		t.Errorf("Expected a BadPayloadSize error. Got %#v", err)
+	}
+}
+
+func assertNilError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Errorf("Expected no error, but got %v", err)
+	}
+}
+
+type successfulBackend struct{}
+
+func (b *successfulBackend) Get(ctx context.Context, key string) (string, error) {
+	return "some-value", nil
+}
+
+func (b *successfulBackend) Put(ctx context.Context, key string, value string) error {
+	return nil
+}

--- a/endpoints/integration_test.go
+++ b/endpoints/integration_test.go
@@ -57,7 +57,7 @@ func expectStored(t *testing.T, putBody string, expectedGet string, expectedMime
 	router := httprouter.New()
 	backend := backends.NewMemoryBackend()
 
-	router.POST("/cache", NewPutHandler(backend, 10*1024, 10))
+	router.POST("/cache", NewPutHandler(backend, 10))
 	router.GET("/cache", NewGetHandler(backend))
 
 	uuid, putTrace := doMockPut(t, router, putBody)
@@ -85,7 +85,7 @@ func expectStored(t *testing.T, putBody string, expectedGet string, expectedMime
 func expectFailedPut(t *testing.T, requestBody string) {
 	backend := backends.NewMemoryBackend()
 	router := httprouter.New()
-	router.POST("/cache", NewPutHandler(backend, 10*1024, 10))
+	router.POST("/cache", NewPutHandler(backend, 10))
 
 	_, putTrace := doMockPut(t, router, requestBody)
 	if putTrace.Code != http.StatusBadRequest {

--- a/endpoints/put.go
+++ b/endpoints/put.go
@@ -12,11 +12,13 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
 	"github.com/prebid/prebid-cache/backends"
+	backendDecorators "github.com/prebid/prebid-cache/backends/decorators"
+
 	"github.com/satori/go.uuid"
 )
 
 // PutHandler serves "POST /cache" requests.
-func NewPutHandler(backend backends.Backend, maxSizeBytes int, maxNumValues int) func(http.ResponseWriter, *http.Request, httprouter.Params) {
+func NewPutHandler(backend backends.Backend, maxNumValues int) func(http.ResponseWriter, *http.Request, httprouter.Params) {
 	// TODO(future PR): Break this giant function apart
 	putAnyRequestPool := sync.Pool{
 		New: func() interface{} {
@@ -57,11 +59,6 @@ func NewPutHandler(backend backends.Backend, maxSizeBytes int, maxNumValues int)
 		defer putResponsePool.Put(resps)
 
 		for i, p := range put.Puts {
-			if len(p.Value) > maxSizeBytes {
-				http.Error(w, fmt.Sprintf("Value is larger than allowed size: %d", maxSizeBytes), http.StatusBadRequest)
-				return
-			}
-
 			if len(p.Value) == 0 {
 				http.Error(w, "Missing value.", http.StatusBadRequest)
 				return
@@ -93,11 +90,18 @@ func NewPutHandler(backend backends.Backend, maxSizeBytes int, maxNumValues int)
 			err = backend.Put(ctx, resps.Responses[i].UUID, toCache)
 
 			if err != nil {
-				logrus.Error("POST /cache Error while writing to the backend:", err)
+				if _, ok := err.(*backendDecorators.BadPayloadSize); ok {
+					http.Error(w, fmt.Sprintf("POST /cache element %d exceeded max size: %v", i, err), http.StatusBadRequest)
+					return
+				}
+
+				logrus.Error("POST /cache Error while writing to the backend: ", err)
 				switch err {
 				case context.DeadlineExceeded:
+					logrus.Error("POST /cache timed out:", err)
 					http.Error(w, "Timeout writing value to the backend", HttpDependencyTimeout)
 				default:
+					logrus.Error("POST /cache had an unexpected error:", err)
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 				}
 				return

--- a/main.go
+++ b/main.go
@@ -76,10 +76,10 @@ func main() {
 	if maxSize := viper.GetInt("request_limits.max_size_bytes"); maxSize > 0 {
 		backend = backendDecorators.EnforceSizeLimit(backend, maxSize)
 	}
+	backend = backendDecorators.LogMetrics(backend, appMetrics)
 	if viper.GetString("compression.type") == "snappy" {
 		backend = compression.SnappyCompress(backend)
 	}
-	backend = backendDecorators.LogMetrics(backend, appMetrics)
 
 	router := httprouter.New()
 	router.GET("/status", endpoints.Status) // Determines whether the server is ready for more traffic.


### PR DESCRIPTION
Followup from #20.

This addresses two issues:

- Payload size limits are enforced _after_ compression
- Size metrics are taken for _all_ payloads (even those which are rejected for size)