### PR TITLE
Respect environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ The service will respond to requests on `localhost:2424`, and the admin data wil
 Configuration is handled by [Viper](https://github.com/spf13/viper#putting-values-into-viper).
 The easiest way to set config during development is by editing the [config.yaml](./config.yaml) file.
 
+You can also set the config through environment variables. For example:
+
+```bash
+PBC_COMPRESSION_TYPE=none ./prebid-cache
+```
+
 ### Docker
 
 Prebid Cache works in Docker out of the box.

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/viper"
 )
@@ -17,6 +19,12 @@ func NewConfig() Configuration {
 	v.AddConfigPath("/etc/prebid-cache/")  // path to look for the config file in
 	v.AddConfigPath("$HOME/.prebid-cache") // call multiple times to add many search paths
 	v.AddConfigPath(".")
+
+	// Support environment variables
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetEnvPrefix("PBC")
+	viper.AutomaticEnv()
+
 	if err := v.ReadInConfig(); err != nil {
 		log.Fatalf("Failed to load config: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -9,21 +9,9 @@ import (
 
 func NewConfig() Configuration {
 	v := viper.New()
-
-	v.SetDefault("rate_limiter.enabled", true)
-	v.SetDefault("rate_limiter.num_requests", 100)
-	v.SetDefault("request_limits.max_size_bytes", 10*1024)
-	v.SetDefault("request_limits.max_num_values", 10)
-
-	v.SetConfigName("config")              // name of config file (without extension)
-	v.AddConfigPath("/etc/prebid-cache/")  // path to look for the config file in
-	v.AddConfigPath("$HOME/.prebid-cache") // call multiple times to add many search paths
-	v.AddConfigPath(".")
-
-	// Support environment variables
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	viper.SetEnvPrefix("PBC")
-	viper.AutomaticEnv()
+	setConfigDefaults(v)
+	setConfigFile(v)
+	setEnvVars(v)
 
 	if err := v.ReadInConfig(); err != nil {
 		log.Fatalf("Failed to load config: %v", err)
@@ -34,6 +22,26 @@ func NewConfig() Configuration {
 	}
 
 	return cfg
+}
+
+func setConfigDefaults(v *viper.Viper) {
+	v.SetDefault("rate_limiter.enabled", true)
+	v.SetDefault("rate_limiter.num_requests", 100)
+	v.SetDefault("request_limits.max_size_bytes", 10*1024)
+	v.SetDefault("request_limits.max_num_values", 10)
+}
+
+func setConfigFile(v *viper.Viper) {
+	v.SetConfigName("config")              // name of config file (without extension)
+	v.AddConfigPath("/etc/prebid-cache/")  // path to look for the config file in
+	v.AddConfigPath("$HOME/.prebid-cache") // call multiple times to add many search paths
+	v.AddConfigPath(".")
+}
+
+func setEnvVars(v *viper.Viper) {
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.SetEnvPrefix("PBC")
+	v.AutomaticEnv()
 }
 
 type Configuration struct {


### PR DESCRIPTION
This makes Prebid Cache respect environment variables, like `PBC_PORT` or `PBC_COMPRESSION_TYPE`.

 Basically the PBC analogue to https://github.com/prebid/prebid-server/pull/407.