### PR TITLE
Adding a metrics type "none"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,7 +25,9 @@ backend:
 compression:
   type: "snappy" # Can also be "none"
 metrics:
-  host: "default-metrics-host"
-  database: "default-metrics-database"
-  username: "metrics-username"
-  password: "metrics-password"
+  type: "none" # Can also be "influx"
+  influx:
+    host: "http://influx.prebid.com"
+    database: "some-database"
+    username: "influx-username"
+    password: "influx-password"

--- a/config/config.go
+++ b/config/config.go
@@ -91,6 +91,18 @@ const (
 )
 
 type Metrics struct {
+	Type   MetricsType `mapstructure:"type"`
+	Influx Influx      `mapstructure:"influx"`
+}
+
+type MetricsType string
+
+const (
+	MetricsNone   MetricsType = "none"
+	MetricsInflux MetricsType = "influx"
+)
+
+type Influx struct {
 	Host     string `mapstructure:"host"`
 	Database string `mapstructure:"database"`
 	Username string `mapstructure:"username"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,10 +33,11 @@ func TestSampleConfig(t *testing.T) {
 	assertStringsEqual(t, "backend.cassandra.keyspace", cfg.Backend.Cassandra.Keyspace, "prebid")
 	assertStringsEqual(t, "backend.memcache.hosts", cfg.Backend.Memcache.Hosts[0], "10.0.0.1:11211")
 	assertStringsEqual(t, "compression.type", string(cfg.Compression.Type), "snappy")
-	assertStringsEqual(t, "metrics.host", cfg.Metrics.Host, "default-metrics-host")
-	assertStringsEqual(t, "metrics.database", cfg.Metrics.Database, "default-metrics-database")
-	assertStringsEqual(t, "metrics.username", cfg.Metrics.Username, "metrics-username")
-	assertStringsEqual(t, "metrics.password", cfg.Metrics.Password, "metrics-password")
+	assertStringsEqual(t, "metrics.type", string(cfg.Metrics.Type), "none")
+	assertStringsEqual(t, "metrics.influx.host", cfg.Metrics.Influx.Host, "default-metrics-host")
+	assertStringsEqual(t, "metrics.influx.database", cfg.Metrics.Influx.Database, "default-metrics-database")
+	assertStringsEqual(t, "metrics.influx.username", cfg.Metrics.Influx.Username, "metrics-username")
+	assertStringsEqual(t, "metrics.influx.password", cfg.Metrics.Influx.Password, "metrics-password")
 }
 
 func TestEnvConfig(t *testing.T) {
@@ -97,10 +98,12 @@ backend:
 compression:
   type: "snappy"
 metrics:
-  host: "default-metrics-host"
-  database: "default-metrics-database"
-  username: "metrics-username"
-  password: "metrics-password"
+  type: "none"
+  influx:
+    host: "default-metrics-host"
+    database: "default-metrics-database"
+    username: "metrics-username"
+    password: "metrics-password"
 `
 
 func assertBoolsEqual(t *testing.T, path string, actual bool, expected bool) {

--- a/metrics/core.go
+++ b/metrics/core.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/prebid/prebid-cache/config"
 	"github.com/rcrowley/go-metrics"
 	"github.com/vrischmann/go-metrics-influxdb"
@@ -73,16 +74,23 @@ type Metrics struct {
 // Export begins sending metrics to the configured database.
 // This method blocks indefinitely, so it should probably be run in a goroutine.
 func (m *Metrics) Export(cfg config.Metrics) {
-	if cfg.Host != "" {
+	switch cfg.Type {
+	case config.MetricsInflux:
+		logrus.Infof("Metrics will be exported to Influx with host=%s, db=%s, username=%s", cfg.Influx.Host, cfg.Influx.Database, cfg.Influx.Username)
 		influxdb.InfluxDB(
-			m.Registry,     // metrics registry
-			time.Second*10, // interval
-			cfg.Host,       // the InfluxDB url
-			cfg.Database,   // your InfluxDB database
-			cfg.Username,   // your InfluxDB user
-			cfg.Password,   // your InfluxDB password
+			m.Registry,          // metrics registry
+			time.Second*10,      // interval
+			cfg.Influx.Host,     // the InfluxDB url
+			cfg.Influx.Database, // your InfluxDB database
+			cfg.Influx.Username, // your InfluxDB user
+			cfg.Influx.Password, // your InfluxDB password
 		)
+	case config.MetricsNone:
+		return
+	default:
+		logrus.Fatalf("Unrecognized config metrics.type: %s", cfg.Type)
 	}
+	return
 }
 
 func CreateMetrics() *Metrics {

--- a/metrics/core.go
+++ b/metrics/core.go
@@ -73,14 +73,16 @@ type Metrics struct {
 // Export begins sending metrics to the configured database.
 // This method blocks indefinitely, so it should probably be run in a goroutine.
 func (m *Metrics) Export(cfg config.Metrics) {
-	influxdb.InfluxDB(
-		m.Registry,     // metrics registry
-		time.Second*10, // interval
-		cfg.Host,       // the InfluxDB url
-		cfg.Database,   // your InfluxDB database
-		cfg.Username,   // your InfluxDB user
-		cfg.Password,   // your InfluxDB password
-	)
+	if cfg.Host != "" {
+		influxdb.InfluxDB(
+			m.Registry,     // metrics registry
+			time.Second*10, // interval
+			cfg.Host,       // the InfluxDB url
+			cfg.Database,   // your InfluxDB database
+			cfg.Username,   // your InfluxDB user
+			cfg.Password,   // your InfluxDB password
+		)
+	}
 }
 
 func CreateMetrics() *Metrics {


### PR DESCRIPTION
This has been bugging me a lot during development. Since there's very little reason to run influx locally, a bunch of error messages spew out to the terminal periodically:

```
2018/05/03 09:29:26 got error while sending a ping to InfluxDB, trying to recreate client. err=Get http://influx.prebid.com/ping: dial tcp: lookup influx.prebid.com: no such host
```

This makes the default metrics "none", so that things run smooth locally.