### PR TITLE
Log config values on startup

### DIFF
--- a/config/backends.go
+++ b/config/backends.go
@@ -1,11 +1,30 @@
 package config
 
+import log "github.com/Sirupsen/logrus"
+
 type Backend struct {
 	Type      BackendType `mapstructure:"type"`
 	Aerospike Aerospike   `mapstructure:"aerospike"`
 	Azure     Azure       `mapstructure:"azure"`
 	Cassandra Cassandra   `mapstructure:"cassandra"`
 	Memcache  Memcache    `mapstructure:"memcache"`
+}
+
+func (cfg *Backend) logValues() {
+	log.Infof("config.backend.type: %s", cfg.Type)
+	switch cfg.Type {
+	case BackendAerospike:
+		cfg.Aerospike.logValues()
+	case BackendAzure:
+		cfg.Azure.logValues()
+	case BackendCassandra:
+		cfg.Cassandra.logValues()
+	case BackendMemcache:
+		cfg.Memcache.logValues()
+	case BackendMemory:
+	default:
+		log.Fatalf(`invalid config.backend.type: %s. It must be "aerospike", "azure", "cassandra", "memcache", or "memory".`, cfg.Type)
+	}
 }
 
 type BackendType string
@@ -24,9 +43,20 @@ type Aerospike struct {
 	Namespace string `mapstructure:"namespace"`
 }
 
+func (cfg *Aerospike) logValues() {
+	log.Infof("config.backend.aerospike.host: %s", cfg.Host)
+	log.Infof("config.backend.aerospike.port: %d", cfg.Port)
+	log.Infof("config.backend.aerospike.namespace: %s", cfg.Namespace)
+}
+
 type Azure struct {
 	Account string `mapstructure:"account"`
 	Key     string `mapstructure:"key"`
+}
+
+func (cfg *Azure) logValues() {
+	log.Infof("config.backend.azure.account: %s", cfg.Account)
+	log.Infof("config.backend.azure.key: %s", cfg.Key)
 }
 
 type Cassandra struct {
@@ -34,6 +64,15 @@ type Cassandra struct {
 	Keyspace string `mapstructure:"keyspace"`
 }
 
+func (cfg *Cassandra) logValues() {
+	log.Infof("config.backend.cassandra.hosts: %s", cfg.Hosts)
+	log.Infof("config.backend.cassandra.keyspace: %s", cfg.Keyspace)
+}
+
 type Memcache struct {
 	Hosts []string `mapstructure:"hosts"`
+}
+
+func (cfg *Memcache) logValues() {
+	log.Infof("config.backend.memcache.hosts: %v", cfg.Hosts)
 }

--- a/config/backends.go
+++ b/config/backends.go
@@ -10,17 +10,17 @@ type Backend struct {
 	Memcache  Memcache    `mapstructure:"memcache"`
 }
 
-func (cfg *Backend) logValues() {
+func (cfg *Backend) validateAndLog() {
 	log.Infof("config.backend.type: %s", cfg.Type)
 	switch cfg.Type {
 	case BackendAerospike:
-		cfg.Aerospike.logValues()
+		cfg.Aerospike.validateAndLog()
 	case BackendAzure:
-		cfg.Azure.logValues()
+		cfg.Azure.validateAndLog()
 	case BackendCassandra:
-		cfg.Cassandra.logValues()
+		cfg.Cassandra.validateAndLog()
 	case BackendMemcache:
-		cfg.Memcache.logValues()
+		cfg.Memcache.validateAndLog()
 	case BackendMemory:
 	default:
 		log.Fatalf(`invalid config.backend.type: %s. It must be "aerospike", "azure", "cassandra", "memcache", or "memory".`, cfg.Type)
@@ -43,7 +43,7 @@ type Aerospike struct {
 	Namespace string `mapstructure:"namespace"`
 }
 
-func (cfg *Aerospike) logValues() {
+func (cfg *Aerospike) validateAndLog() {
 	log.Infof("config.backend.aerospike.host: %s", cfg.Host)
 	log.Infof("config.backend.aerospike.port: %d", cfg.Port)
 	log.Infof("config.backend.aerospike.namespace: %s", cfg.Namespace)
@@ -54,7 +54,7 @@ type Azure struct {
 	Key     string `mapstructure:"key"`
 }
 
-func (cfg *Azure) logValues() {
+func (cfg *Azure) validateAndLog() {
 	log.Infof("config.backend.azure.account: %s", cfg.Account)
 	log.Infof("config.backend.azure.key: %s", cfg.Key)
 }
@@ -64,7 +64,7 @@ type Cassandra struct {
 	Keyspace string `mapstructure:"keyspace"`
 }
 
-func (cfg *Cassandra) logValues() {
+func (cfg *Cassandra) validateAndLog() {
 	log.Infof("config.backend.cassandra.hosts: %s", cfg.Hosts)
 	log.Infof("config.backend.cassandra.keyspace: %s", cfg.Keyspace)
 }
@@ -73,6 +73,6 @@ type Memcache struct {
 	Hosts []string `mapstructure:"hosts"`
 }
 
-func (cfg *Memcache) logValues() {
+func (cfg *Memcache) validateAndLog() {
 	log.Infof("config.backend.memcache.hosts: %v", cfg.Hosts)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -55,8 +55,23 @@ type Configuration struct {
 	Metrics       Metrics       `mapstructure:"metrics"`
 }
 
+func (cfg *Configuration) LogValues() {
+	log.Infof("config.port: %d", cfg.Port)
+	log.Infof("config.admin_port: %d", cfg.AdminPort)
+	cfg.Log.logValues()
+	cfg.RateLimiting.logValues()
+	cfg.RequestLimits.logValues()
+	cfg.Backend.logValues()
+	cfg.Compression.logValues()
+	cfg.Metrics.logValues()
+}
+
 type Log struct {
 	Level LogLevel `mapstructure:"level"`
+}
+
+func (cfg *Log) logValues() {
+	log.Infof("config.log.level: %s", cfg.Level)
 }
 
 type LogLevel string
@@ -75,13 +90,27 @@ type RateLimiting struct {
 	MaxRequestsPerSecond int64 `mapstructure:"num_requests"`
 }
 
+func (cfg *RateLimiting) logValues() {
+	log.Infof("config.rate_limiter.enabled: %t", cfg.Enabled)
+	log.Infof("config.rate_limiter.num_requests: %d", cfg.MaxRequestsPerSecond)
+}
+
 type RequestLimits struct {
 	MaxSize      int `mapstructure:"max_size_bytes"`
 	MaxNumValues int `mapstructure:"max_num_values"`
 }
 
+func (cfg *RequestLimits) logValues() {
+	log.Infof("config.request_limits.max_size_bytes: %d", cfg.MaxSize)
+	log.Infof("config.request_limits.max_num_values: %d", cfg.MaxNumValues)
+}
+
 type Compression struct {
 	Type CompressionType
+}
+
+func (cfg *Compression) logValues() {
+	log.Infof("config.compression.type: %s", cfg.Type)
 }
 
 type CompressionType string
@@ -93,6 +122,17 @@ const (
 type Metrics struct {
 	Type   MetricsType `mapstructure:"type"`
 	Influx Influx      `mapstructure:"influx"`
+}
+
+func (cfg *Metrics) logValues() {
+	log.Infof("config.metrics.type: %s", cfg.Type)
+	switch cfg.Type {
+	case MetricsNone:
+	case MetricsInflux:
+		cfg.Influx.logValues()
+	default:
+		log.Fatalf(`invalid config.metrics.type: %s. It must be "none" or "influx"`, cfg.Type)
+	}
 }
 
 type MetricsType string
@@ -107,4 +147,10 @@ type Influx struct {
 	Database string `mapstructure:"database"`
 	Username string `mapstructure:"username"`
 	Password string `mapstructure:"password"`
+}
+
+func (cfg *Influx) logValues() {
+	log.Infof("config.metrics.influx.host: %s", cfg.Host)
+	log.Infof("config.metrics.influx.database: %s", cfg.Database)
+	// This intentionally skips username and password for security reasons.
 }

--- a/config/config.go
+++ b/config/config.go
@@ -55,22 +55,24 @@ type Configuration struct {
 	Metrics       Metrics       `mapstructure:"metrics"`
 }
 
-func (cfg *Configuration) LogValues() {
+// ValidateAndLog validates the config, terminating the program on any errors.
+// It also logs the config values that it used.
+func (cfg *Configuration) ValidateAndLog() {
 	log.Infof("config.port: %d", cfg.Port)
 	log.Infof("config.admin_port: %d", cfg.AdminPort)
-	cfg.Log.logValues()
-	cfg.RateLimiting.logValues()
-	cfg.RequestLimits.logValues()
-	cfg.Backend.logValues()
-	cfg.Compression.logValues()
-	cfg.Metrics.logValues()
+	cfg.Log.validateAndLog()
+	cfg.RateLimiting.validateAndLog()
+	cfg.RequestLimits.validateAndLog()
+	cfg.Backend.validateAndLog()
+	cfg.Compression.validateAndLog()
+	cfg.Metrics.validateAndLog()
 }
 
 type Log struct {
 	Level LogLevel `mapstructure:"level"`
 }
 
-func (cfg *Log) logValues() {
+func (cfg *Log) validateAndLog() {
 	log.Infof("config.log.level: %s", cfg.Level)
 }
 
@@ -90,7 +92,7 @@ type RateLimiting struct {
 	MaxRequestsPerSecond int64 `mapstructure:"num_requests"`
 }
 
-func (cfg *RateLimiting) logValues() {
+func (cfg *RateLimiting) validateAndLog() {
 	log.Infof("config.rate_limiter.enabled: %t", cfg.Enabled)
 	log.Infof("config.rate_limiter.num_requests: %d", cfg.MaxRequestsPerSecond)
 }
@@ -100,7 +102,7 @@ type RequestLimits struct {
 	MaxNumValues int `mapstructure:"max_num_values"`
 }
 
-func (cfg *RequestLimits) logValues() {
+func (cfg *RequestLimits) validateAndLog() {
 	log.Infof("config.request_limits.max_size_bytes: %d", cfg.MaxSize)
 	log.Infof("config.request_limits.max_num_values: %d", cfg.MaxNumValues)
 }
@@ -109,13 +111,21 @@ type Compression struct {
 	Type CompressionType
 }
 
-func (cfg *Compression) logValues() {
-	log.Infof("config.compression.type: %s", cfg.Type)
+func (cfg *Compression) validateAndLog() {
+	switch cfg.Type {
+	case CompressionNone:
+		fallthrough
+	case CompressionSnappy:
+		log.Infof("config.compression.type: %s", cfg.Type)
+	default:
+		log.Fatalf(`invalid config.compression.type: %s. It must be "none" or "snappy"`, cfg.Type)
+	}
 }
 
 type CompressionType string
 
 const (
+	CompressionNone   CompressionType = "none"
 	CompressionSnappy CompressionType = "snappy"
 )
 
@@ -124,12 +134,12 @@ type Metrics struct {
 	Influx Influx      `mapstructure:"influx"`
 }
 
-func (cfg *Metrics) logValues() {
+func (cfg *Metrics) validateAndLog() {
 	log.Infof("config.metrics.type: %s", cfg.Type)
 	switch cfg.Type {
 	case MetricsNone:
 	case MetricsInflux:
-		cfg.Influx.logValues()
+		cfg.Influx.validateAndLog()
 	default:
 		log.Fatalf(`invalid config.metrics.type: %s. It must be "none" or "influx"`, cfg.Type)
 	}
@@ -149,7 +159,7 @@ type Influx struct {
 	Password string `mapstructure:"password"`
 }
 
-func (cfg *Influx) logValues() {
+func (cfg *Influx) validateAndLog() {
 	log.Infof("config.metrics.influx.host: %s", cfg.Host)
 	log.Infof("config.metrics.influx.database: %s", cfg.Database)
 	// This intentionally skips username and password for security reasons.

--- a/main.go
+++ b/main.go
@@ -14,8 +14,11 @@ import (
 )
 
 func main() {
+	log.SetOutput(os.Stdout)
 	cfg := config.NewConfig()
-	initLogging(cfg)
+	setLogLevel(cfg.Log.Level)
+	cfg.LogValues()
+
 	appMetrics := metrics.CreateMetrics()
 	backend := backendConfig.NewBackend(cfg, appMetrics)
 	handler := routing.NewHandler(cfg, backend, appMetrics)
@@ -23,12 +26,10 @@ func main() {
 	server.Listen(cfg, handler, appMetrics.Connections)
 }
 
-func initLogging(cfg config.Configuration) {
-	level, err := log.ParseLevel(string(cfg.Log.Level))
+func setLogLevel(logLevel config.LogLevel) {
+	level, err := log.ParseLevel(string(logLevel))
 	if err != nil {
 		log.Fatalf("Invalid logrus level: %v", err)
 	}
-	log.SetOutput(os.Stdout)
 	log.SetLevel(level)
-	log.Info("Log level set to: ", log.GetLevel())
 }

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 	log.SetOutput(os.Stdout)
 	cfg := config.NewConfig()
 	setLogLevel(cfg.Log.Level)
-	cfg.LogValues()
+	cfg.ValidateAndLog()
 
 	appMetrics := metrics.CreateMetrics()
 	backend := backendConfig.NewBackend(cfg, appMetrics)


### PR DESCRIPTION
To make it very explicit which configuration values the app is running, unless they pose security risks (e.g. `password`).

Output on startup looks like this:

```
dbemiller-mac:prebid-cache dbemiller$ ./prebid-cache 
INFO[0000] config.port: 2424                            
INFO[0000] config.admin_port: 2525                      
INFO[0000] config.log.level: info                       
INFO[0000] config.rate_limiter.enabled: true            
INFO[0000] config.rate_limiter.num_requests: 100        
INFO[0000] config.request_limits.max_size_bytes: 10240  
INFO[0000] config.request_limits.max_num_values: 10     
INFO[0000] config.backend.type: memory                  
INFO[0000] config.compression.type: snappy              
INFO[0000] config.metrics.type: none                    
INFO[0000] Main server starting on: :2424               
INFO[0000] Admin server starting on: :2525
```

Bad values terminate the process immediately:

```
dbemiller-mac:prebid-cache dbemiller$ ./prebid-cache 
INFO[0000] config.port: 2424                            
INFO[0000] config.admin_port: 2525                      
INFO[0000] config.log.level: info                       
INFO[0000] config.rate_limiter.enabled: true            
INFO[0000] config.rate_limiter.num_requests: 100        
INFO[0000] config.request_limits.max_size_bytes: 10240  
INFO[0000] config.request_limits.max_num_values: 10     
INFO[0000] config.backend.type: unknown                 
FATA[0000] invalid config.backend.type: unknown. It must be "aerospike", "azure", "cassandra", "memcache", or "memory".
```