### PR TITLE
Removed explicit viper.Get() calls

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -108,7 +108,7 @@ func (cfg *RequestLimits) validateAndLog() {
 }
 
 type Compression struct {
-	Type CompressionType
+	Type CompressionType `mapstructure:"type"`
 }
 
 func (cfg *Compression) validateAndLog() {


### PR DESCRIPTION
We had a bug related to this in Prebid Server... and I stumbled on this while doing other stuff. Figured I'd remove it before we hit the same issue here.