### PR TITLE
Swapped the order on metrics/compression.

### DIFF
--- a/backends/config/config.go
+++ b/backends/config/config.go
@@ -15,8 +15,11 @@ func NewBackend(cfg config.Configuration, appMetrics *metrics.Metrics) backends.
 	if cfg.RequestLimits.MaxSize > 0 {
 		backend = decorators.EnforceSizeLimit(backend, cfg.RequestLimits.MaxSize)
 	}
-	backend = decorators.LogMetrics(backend, appMetrics)
+	// Metrics must be taken _before_ compression because it relies on the
+	// "json" or "xml" prefix on the payload. Compression might munge this.
+	// We should re-work this strategy at some point.
 	backend = applyCompression(cfg.Compression, backend)
+	backend = decorators.LogMetrics(backend, appMetrics)
 	return backend
 }
 


### PR DESCRIPTION
See the code comment for rationale... if that doesn't explain it, let me know and I'll try to make it more clear.

Only real reason I'm doing the quick fix here is because I want to test some new deployment scripts today, and if we're gonna release on a Friday, we should do it early.