### PR TITLE
Added aerospike expiry metrics

### DIFF
--- a/backends/config/config.go
+++ b/backends/config/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 func NewBackend(cfg config.Configuration, appMetrics *metrics.Metrics) backends.Backend {
-	backend := newBaseBackend(cfg.Backend)
+	backend := newBaseBackend(cfg.Backend, appMetrics)
 	backend = decorators.LimitTTLs(backend, cfg.RequestLimits.MaxTTLSeconds)
 	if cfg.RequestLimits.MaxSize > 0 {
 		backend = decorators.EnforceSizeLimit(backend, cfg.RequestLimits.MaxSize)
@@ -37,7 +37,7 @@ func applyCompression(cfg config.Compression, backend backends.Backend) backends
 	panic("Error applying compression. This shouldn't happen.")
 }
 
-func newBaseBackend(cfg config.Backend) backends.Backend {
+func newBaseBackend(cfg config.Backend, appMetrics *metrics.Metrics) backends.Backend {
 	switch cfg.Type {
 	case config.BackendCassandra:
 		return backends.NewCassandraBackend(cfg.Cassandra)
@@ -48,7 +48,7 @@ func newBaseBackend(cfg config.Backend) backends.Backend {
 	case config.BackendAzure:
 		return backends.NewAzureBackend(cfg.Azure.Account, cfg.Azure.Key)
 	case config.BackendAerospike:
-		return backends.NewAerospikeBackend(cfg.Aerospike)
+		return backends.NewAerospikeBackend(cfg.Aerospike, appMetrics.ExtraTTLSeconds)
 	case config.BackendRedis:
 		return backends.NewRedisBackend(cfg.Redis)
 	default:

--- a/backends/decorators/metrics.go
+++ b/backends/decorators/metrics.go
@@ -35,6 +35,9 @@ func (b *backendWithMetrics) Put(ctx context.Context, key string, value string, 
 	} else {
 		b.puts.InvalidRequest.Mark(1)
 	}
+	if ttlSeconds != 0 {
+		b.puts.DefinesTTL.Mark(1)
+	}
 	start := time.Now()
 	err := b.delegate.Put(ctx, key, value, ttlSeconds)
 	if err == nil {

--- a/backends/decorators/metrics_test.go
+++ b/backends/decorators/metrics_test.go
@@ -47,6 +47,18 @@ func TestPutSuccessMetrics(t *testing.T) {
 	if m.PutsBackend.XmlRequest.Count() != 1 {
 		t.Errorf("An xml request should have been logged.")
 	}
+	if m.PutsBackend.DefinesTTL.Count() != 0 {
+		t.Errorf("An event for TTL defined shouldn't be logged if the TTL was 0")
+	}
+}
+
+func TestTTLDefinedMetrics(t *testing.T) {
+	m := metrics.CreateMetrics()
+	backend := LogMetrics(backends.NewMemoryBackend(), m)
+	backend.Put(context.Background(), "foo", "xml<vast></vast>", 1)
+	if m.PutsBackend.DefinesTTL.Count() != 1 {
+		t.Errorf("An event for TTL defined should be logged if the TTL is not 0")
+	}
 }
 
 func TestPutErrorMetrics(t *testing.T) {

--- a/metrics/core.go
+++ b/metrics/core.go
@@ -23,6 +23,7 @@ type MetricsEntryByFormat struct {
 	BadRequest     metrics.Meter
 	JsonRequest    metrics.Meter
 	XmlRequest     metrics.Meter
+	DefinesTTL     metrics.Meter
 	InvalidRequest metrics.Meter
 	RequestLength  metrics.Histogram
 }
@@ -42,13 +43,14 @@ func NewMetricsEntry(name string, r metrics.Registry) *MetricsEntry {
 	}
 }
 
-func NewMetricsEntryByType(name string, r metrics.Registry) *MetricsEntryByFormat {
+func NewMetricsEntryBackendPuts(name string, r metrics.Registry) *MetricsEntryByFormat {
 	return &MetricsEntryByFormat{
 		Duration:       metrics.GetOrRegisterTimer(fmt.Sprintf("%s.request_duration", name), r),
 		Errors:         metrics.GetOrRegisterMeter(fmt.Sprintf("%s.error_count", name), r),
 		BadRequest:     metrics.GetOrRegisterMeter(fmt.Sprintf("%s.bad_request_count", name), r),
 		JsonRequest:    metrics.GetOrRegisterMeter(fmt.Sprintf("%s.json_request_count", name), r),
 		XmlRequest:     metrics.GetOrRegisterMeter(fmt.Sprintf("%s.xml_request_count", name), r),
+		DefinesTTL:     metrics.GetOrRegisterMeter(fmt.Sprintf("%s.defines_ttl", name), r),
 		InvalidRequest: metrics.GetOrRegisterMeter(fmt.Sprintf("%s.unknown_request_count", name), r),
 		RequestLength:  metrics.GetOrRegisterHistogram(name+".request_size_bytes", r, metrics.NewExpDecaySample(1028, 0.015)),
 	}
@@ -101,7 +103,7 @@ func CreateMetrics() *Metrics {
 		Registry:        r,
 		Puts:            NewMetricsEntry("puts.current_url", r),
 		Gets:            NewMetricsEntry("gets.current_url", r),
-		PutsBackend:     NewMetricsEntryByType("puts.backend", r),
+		PutsBackend:     NewMetricsEntryBackendPuts("puts.backend", r),
 		GetsBackend:     NewMetricsEntry("gets.backend", r),
 		Connections:     NewConnectionMetrics(r),
 		ExtraTTLSeconds: metrics.GetOrRegisterHistogram("extra_ttl_seconds", r, metrics.NewUniformSample(5000)),

--- a/metrics/core.go
+++ b/metrics/core.go
@@ -63,12 +63,13 @@ func NewConnectionMetrics(r metrics.Registry) *ConnectionMetrics {
 }
 
 type Metrics struct {
-	Registry    metrics.Registry
-	Puts        *MetricsEntry
-	Gets        *MetricsEntry
-	PutsBackend *MetricsEntryByFormat
-	GetsBackend *MetricsEntry
-	Connections *ConnectionMetrics
+	Registry        metrics.Registry
+	Puts            *MetricsEntry
+	Gets            *MetricsEntry
+	PutsBackend     *MetricsEntryByFormat
+	GetsBackend     *MetricsEntry
+	Connections     *ConnectionMetrics
+	ExtraTTLSeconds metrics.Histogram
 }
 
 // Export begins sending metrics to the configured database.
@@ -97,12 +98,13 @@ func CreateMetrics() *Metrics {
 	flushTime := time.Second * 10
 	r := metrics.NewPrefixedRegistry("prebidcache.")
 	m := &Metrics{
-		Registry:    r,
-		Puts:        NewMetricsEntry("puts.current_url", r),
-		Gets:        NewMetricsEntry("gets.current_url", r),
-		PutsBackend: NewMetricsEntryByType("puts.backend", r),
-		GetsBackend: NewMetricsEntry("gets.backend", r),
-		Connections: NewConnectionMetrics(r),
+		Registry:        r,
+		Puts:            NewMetricsEntry("puts.current_url", r),
+		Gets:            NewMetricsEntry("gets.current_url", r),
+		PutsBackend:     NewMetricsEntryByType("puts.backend", r),
+		GetsBackend:     NewMetricsEntry("gets.backend", r),
+		Connections:     NewConnectionMetrics(r),
+		ExtraTTLSeconds: metrics.GetOrRegisterHistogram("extra_ttl_seconds", r, metrics.NewUniformSample(5000)),
 	}
 
 	metrics.RegisterDebugGCStats(m.Registry)


### PR DESCRIPTION
Adding metrics to tell:

- How many objects define TTLs through the API
- How much longer an object would have remained in the cache, for Aerospike

Goal here is to help PBS hosts tune the configurable Default TTLs.