### PR TITLE
Concurrent map usage is not safe

### DIFF
--- a/backends/memory.go
+++ b/backends/memory.go
@@ -3,13 +3,18 @@ package backends
 import (
 	"context"
 	"fmt"
+	"sync"
 )
 
 type MemoryBackend struct {
 	db map[string]string
+	mu sync.Mutex
 }
 
 func (b *MemoryBackend) Get(ctx context.Context, key string) (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	v, ok := b.db[key]
 	if !ok {
 		return "", fmt.Errorf("Not found")
@@ -19,6 +24,9 @@ func (b *MemoryBackend) Get(ctx context.Context, key string) (string, error) {
 }
 
 func (b *MemoryBackend) Put(ctx context.Context, key string, value string, ttlSeconds int) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	b.db[key] = value
 	return nil
 }


### PR DESCRIPTION
Using the memory backend can cause panics if we have two request writing at exactly the same time.