### PR TITLE
Fix proper sync.Pool usage

### DIFF
--- a/backends/azure_table.go
+++ b/backends/azure_table.go
@@ -54,7 +54,7 @@ func NewAzureBackend(account string, key string) *AzureTableBackend {
 				buffer[1] = '"'
 				buffer[6] = '"'
 				buffer[7] = ']'
-				return buffer
+				return &buffer
 			},
 		},
 	}
@@ -194,8 +194,8 @@ func (c *AzureTableBackend) makePartitionKey(objectKey string) string {
 }
 
 func (c *AzureTableBackend) wrapForHeader(partitionKey string) string {
-	buffer := c.partitionKeyPool.Get().([8]byte)
+	buffer := c.partitionKeyPool.Get().(*[8]byte)
 	defer c.partitionKeyPool.Put(buffer)
-	copy(buffer[2:6], partitionKey)
-	return string(buffer[:])
+	copy((*buffer)[2:6], partitionKey)
+	return string((*buffer)[:])
 }

--- a/endpoints/put.go
+++ b/endpoints/put.go
@@ -21,13 +21,13 @@ func NewPutHandler(backend backends.Backend, maxNumValues int, allowKeys bool) f
 	// TODO(future PR): Break this giant function apart
 	putAnyRequestPool := sync.Pool{
 		New: func() interface{} {
-			return PutRequest{}
+			return &PutRequest{}
 		},
 	}
 
 	putResponsePool := sync.Pool{
 		New: func() interface{} {
-			return PutResponse{}
+			return &PutResponse{}
 		},
 	}
 
@@ -39,10 +39,10 @@ func NewPutHandler(backend backends.Backend, maxNumValues int, allowKeys bool) f
 		}
 		defer r.Body.Close()
 
-		put := putAnyRequestPool.Get().(PutRequest)
+		put := putAnyRequestPool.Get().(*PutRequest)
 		defer putAnyRequestPool.Put(put)
 
-		err = json.Unmarshal(body, &put)
+		err = json.Unmarshal(body, put)
 		if err != nil {
 			http.Error(w, "Request body "+string(body)+" is not valid JSON.", http.StatusBadRequest)
 			return
@@ -53,7 +53,7 @@ func NewPutHandler(backend backends.Backend, maxNumValues int, allowKeys bool) f
 			return
 		}
 
-		resps := putResponsePool.Get().(PutResponse)
+		resps := putResponsePool.Get().(*PutResponse)
 		resps.Responses = make([]PutResponseObject, len(put.Puts))
 		defer putResponsePool.Put(resps)
 
@@ -130,7 +130,7 @@ func NewPutHandler(backend backends.Backend, maxNumValues int, allowKeys bool) f
 
 		}
 
-		bytes, err := json.Marshal(&resps)
+		bytes, err := json.Marshal(resps)
 		if err != nil {
 			http.Error(w, "Failed to serialize UUIDs into JSON.", http.StatusInternalServerError)
 			return


### PR DESCRIPTION
Putting whole objects in a pool only works if you put in pointers. Otherwise the interface{} conversion is still going to cause an allocation.
See: https://play.golang.org/p/dDoWFnuf9bb

When you put a slice in a pool you also need to put in a pointer to the slice.
See: https://play.golang.org/p/yitACT4RLDY