### PR TITLE
disabled rate limiter by default in config.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,18 @@ The easiest way to set config during development is by editing the [config.yaml]
 You can also set the config through environment variables. For example:
 
 ```bash
-PBC_COMPRESSION_TYPE=none ./prebid-cache
+PBC_COMPRESSION_TYPE: "none"
+```
+
+### Rate limiter
+
+Rate limiting uses a lot of memory and is disabled by default. To re-enable rate limiting, set the `PBC_RATE_LIMITER_ENABLED` flag to `true` in the configuration file [config.yaml](./config.yaml). If enabled, the maximum requests per second defaults to 100, this value can also be modified in the configuration file:
+
+Sample rate limiting configuration:
+
+```bash
+PBC_RATE_LIMITER_ENABLED: "true"
+PBC_RATE_LIMITER_NUM_REQUESTS: 150
 ```
 
 ### Docker

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,7 @@ func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("metrics.prometheus.subsystem", "")
 	v.SetDefault("metrics.prometheus.timeout_ms", 0)
 	v.SetDefault("metrics.prometheus.enabled", false)
-	v.SetDefault("rate_limiter.enabled", true)
+	v.SetDefault("rate_limiter.enabled", false)
 	v.SetDefault("rate_limiter.num_requests", 100)
 	v.SetDefault("request_limits.allow_setting_keys", false)
 	v.SetDefault("request_limits.max_size_bytes", 10*1024)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -52,7 +52,7 @@ func TestDefaults(t *testing.T) {
 	assertStringsEqual(t, "metrics.prometheus.subsystem", cfg.Metrics.Prometheus.Subsystem, "")
 	assertIntsEqual(t, "metrics.prometheus.timeout_ms", cfg.Metrics.Prometheus.TimeoutMillisRaw, 0)
 	assertBoolsEqual(t, "metrics.prometheus.enabled", cfg.Metrics.Prometheus.Enabled, false)
-	assertBoolsEqual(t, "rate_limiter.enabled", cfg.RateLimiting.Enabled, true)
+	assertBoolsEqual(t, "rate_limiter.enabled", cfg.RateLimiting.Enabled, false)
 	assertInt64sEqual(t, "rate_limiter.num_requests", cfg.RateLimiting.MaxRequestsPerSecond, 100)
 	assertIntsEqual(t, "request_limits.max_size_bytes", cfg.RequestLimits.MaxSize, 10*1024)
 	assertIntsEqual(t, "request_limits.max_num_values", cfg.RequestLimits.MaxNumValues, 10)


### PR DESCRIPTION
The rate limiter can be enabled or disabled in the configuration files. This PR will keep it disabled by default.