### PR TITLE
Add configuration for admin only POST, default route disabling

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,7 @@
 port: 2424
 admin_port: 2525
+default_route_enabled: true
+public_write_enabled: true
 log:
   level: "info"
 rate_limiter:

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,8 @@ func NewConfig() Configuration {
 func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("port", 2424)
 	v.SetDefault("admin_port", 2525)
+	v.SetDefault("default_route_enabled", true)
+	v.SetDefault("public_write_enabled", true)
 	v.SetDefault("log.level", "info")
 	v.SetDefault("backend.type", "memory")
 	v.SetDefault("backend.aerospike.host", "")
@@ -79,14 +81,16 @@ func setEnvVars(v *viper.Viper) {
 }
 
 type Configuration struct {
-	Port          int           `mapstructure:"port"`
-	AdminPort     int           `mapstructure:"admin_port"`
-	Log           Log           `mapstructure:"log"`
-	RateLimiting  RateLimiting  `mapstructure:"rate_limiter"`
-	RequestLimits RequestLimits `mapstructure:"request_limits"`
-	Backend       Backend       `mapstructure:"backend"`
-	Compression   Compression   `mapstructure:"compression"`
-	Metrics       Metrics       `mapstructure:"metrics"`
+	Port                int           `mapstructure:"port"`
+	AdminPort           int           `mapstructure:"admin_port"`
+	DefaultRouteEnabled bool          `mapstructure:"default_route_enabled"`
+	PublicWriteEnabled  bool          `mapstructure:"public_write_enabled"`
+	Log                 Log           `mapstructure:"log"`
+	RateLimiting        RateLimiting  `mapstructure:"rate_limiter"`
+	RequestLimits       RequestLimits `mapstructure:"request_limits"`
+	Backend             Backend       `mapstructure:"backend"`
+	Compression         Compression   `mapstructure:"compression"`
+	Metrics             Metrics       `mapstructure:"metrics"`
 }
 
 // ValidateAndLog validates the config, terminating the program on any errors.

--- a/endpoints/routing/handler.go
+++ b/endpoints/routing/handler.go
@@ -15,16 +15,37 @@ import (
 	"github.com/rs/cors"
 )
 
-func NewHandler(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics) http.Handler {
+func NewAdminHandler(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics) http.Handler {
 	router := httprouter.New()
-	router.GET("/", endpoints.Index)        //Default route handler
-	router.GET("/status", endpoints.Status) // Determines whether the server is ready for more traffic.
-	router.POST("/cache", decorators.MonitorHttp(endpoints.NewPutHandler(dataStore, cfg.RequestLimits.MaxNumValues, cfg.RequestLimits.AllowSettingKeys), appMetrics, decorators.PostMethod))
-	router.GET("/cache", decorators.MonitorHttp(endpoints.NewGetHandler(dataStore, cfg.RequestLimits.AllowSettingKeys), appMetrics, decorators.GetMethod))
+	router = addReadOnlyRoutes(cfg, dataStore, appMetrics, router)
+	router = addWriteRoutes(cfg, dataStore, appMetrics, router)
+	return router
+}
+
+func NewPublicHandler(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics) http.Handler {
+	router := httprouter.New()
+	router = addReadOnlyRoutes(cfg, dataStore, appMetrics, router)
+	if cfg.PublicWriteEnabled {
+		router = addWriteRoutes(cfg, dataStore, appMetrics, router)
+	}
 
 	handler := handleCors(router)
 	handler = handleRateLimiting(handler, cfg.RateLimiting)
-	return handler
+	return router
+}
+
+func addReadOnlyRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) *httprouter.Router {
+	if cfg.DefaultRouteEnabled {
+		router.GET("/", endpoints.Index) //Default route handler
+	}
+	router.GET("/status", endpoints.Status) // Determines whether the server is ready for more traffic.
+	router.GET("/cache", decorators.MonitorHttp(endpoints.NewGetHandler(dataStore, cfg.RequestLimits.AllowSettingKeys), appMetrics, decorators.GetMethod))
+	return router
+}
+
+func addWriteRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) *httprouter.Router {
+	router.POST("/cache", decorators.MonitorHttp(endpoints.NewPutHandler(dataStore, cfg.RequestLimits.MaxNumValues, cfg.RequestLimits.AllowSettingKeys), appMetrics, decorators.PostMethod))
+	return router
 }
 
 func handleCors(handler http.Handler) http.Handler {

--- a/main.go
+++ b/main.go
@@ -21,9 +21,10 @@ func main() {
 
 	appMetrics := metrics.CreateMetrics(cfg)
 	backend := backendConfig.NewBackend(cfg, appMetrics)
-	handler := routing.NewHandler(cfg, backend, appMetrics)
+	publicHandler := routing.NewPublicHandler(cfg, backend, appMetrics)
+	adminHandler := routing.NewAdminHandler(cfg, backend, appMetrics)
 	go appMetrics.Export(cfg)
-	server.Listen(cfg, handler, appMetrics)
+	server.Listen(cfg, publicHandler, adminHandler, appMetrics)
 }
 
 func setLogLevel(logLevel config.LogLevel) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -13,7 +13,7 @@ func TestNewAdminServer(t *testing.T) {
 		Port:      8000,
 		AdminPort: 6060,
 	}
-	server := newAdminServer(cfg)
+	server := newAdminServer(cfg, http.HandlerFunc(handler))
 	if server.Addr != ":6060" {
 		t.Errorf("Admin server address should be %s. Got %s", ":6060", server.Addr)
 	}


### PR DESCRIPTION
We intend on using prebid-cache to cache responses from a backend, and hand out the urls to the cache for the frontend clients to consume. prebid-cache currently exposes both the POST and the GET for cache items to the public API, which is not ideal if we never want the public to be able to write to our cache. It also has a default `/` handler that we'd prefer not to be visible, as it just highlights what the service is.

This change:
- Adds configuration `public_write_enabled` to disable writes on the public port (2424 default)
- Adds a read/write not rate limited handler into the API for the admin port (2525 default)
- Adds configuration `default_route_enabled` to disable the default `/` response

Unsure about:
- The use case for the admin server currently, I'm reusing this as the "private" API, but happy to separate it out. What is the intention of the extra server with no handlers?
- Configuration layout, I made it pretty flat, should I nest the configuration properties differently? `routes.default.enabled`/`routes.public.write.enabled` or something?

Related to https://github.com/prebid/prebid-cache/issues/36 which is asking for this functionality.

Tested it locally with the various flags on/off and it seems to work fine, existing tests are happy but they do not seem to cover much re: poking actual urls.