### PR TITLE
Add configuration for admin only POST, default route message changing

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,5 +43,5 @@ metrics:
     username: "influx-username"
     password: "influx-password"
 routes:
-  index_enabled: true
+  empty_index_response: false # Changes / route to be a 204
   allow_public_write: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,5 @@
 port: 2424
 admin_port: 2525
-default_route_enabled: true
-public_write_enabled: true
 log:
   level: "info"
 rate_limiter:
@@ -44,3 +42,6 @@ metrics:
     database: "some-database"
     username: "influx-username"
     password: "influx-password"
+routes:
+  index_enabled: true
+  allow_public_write: true

--- a/config.yaml
+++ b/config.yaml
@@ -43,5 +43,4 @@ metrics:
     username: "influx-username"
     password: "influx-password"
 routes:
-  empty_index_response: false # Changes / route to be a 204
   allow_public_write: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,7 @@
 port: 2424
 admin_port: 2525
+default_route_enabled: true
+public_write_enabled: true
 log:
   level: "info"
 rate_limiter:

--- a/config/config.go
+++ b/config/config.go
@@ -63,7 +63,7 @@ func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("request_limits.max_size_bytes", 10*1024)
 	v.SetDefault("request_limits.max_num_values", 10)
 	v.SetDefault("request_limits.max_ttl_seconds", 3600)
-	v.SetDefault("routes.empty_index_response", false)
+	v.SetDefault("routes.index_response", "This application stores short-term data for use in Prebid.")
 	v.SetDefault("routes.allow_public_write", true)
 }
 
@@ -264,6 +264,6 @@ func (m *PrometheusMetrics) Timeout() time.Duration {
 }
 
 type Routes struct {
-	EmptyIndexResponse bool `mapstructure:"empty_index_response"`
-	AllowPublicWrite   bool `mapstructure:"allow_public_write"`
+	IndexResponse    string `mapstructure:"index_response"`
+	AllowPublicWrite bool   `mapstructure:"allow_public_write"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ func NewConfig() Configuration {
 func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("port", 2424)
 	v.SetDefault("admin_port", 2525)
+	v.SetDefault("index_response", "This application stores short-term data for use in Prebid.")
 	v.SetDefault("log.level", "info")
 	v.SetDefault("backend.type", "memory")
 	v.SetDefault("backend.aerospike.host", "")
@@ -63,7 +64,6 @@ func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("request_limits.max_size_bytes", 10*1024)
 	v.SetDefault("request_limits.max_num_values", 10)
 	v.SetDefault("request_limits.max_ttl_seconds", 3600)
-	v.SetDefault("routes.index_response", "This application stores short-term data for use in Prebid.")
 	v.SetDefault("routes.allow_public_write", true)
 }
 
@@ -83,6 +83,7 @@ func setEnvVars(v *viper.Viper) {
 type Configuration struct {
 	Port          int           `mapstructure:"port"`
 	AdminPort     int           `mapstructure:"admin_port"`
+	IndexResponse string        `mapstructure:"index_response"`
 	Log           Log           `mapstructure:"log"`
 	RateLimiting  RateLimiting  `mapstructure:"rate_limiter"`
 	RequestLimits RequestLimits `mapstructure:"request_limits"`
@@ -264,6 +265,5 @@ func (m *PrometheusMetrics) Timeout() time.Duration {
 }
 
 type Routes struct {
-	IndexResponse    string `mapstructure:"index_response"`
-	AllowPublicWrite bool   `mapstructure:"allow_public_write"`
+	AllowPublicWrite bool `mapstructure:"allow_public_write"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,8 @@ func NewConfig() Configuration {
 func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("port", 2424)
 	v.SetDefault("admin_port", 2525)
+	v.SetDefault("default_route_enabled", true)
+	v.SetDefault("public_write_enabled", true)
 	v.SetDefault("log.level", "info")
 	v.SetDefault("backend.type", "memory")
 	v.SetDefault("backend.aerospike.host", "")
@@ -79,14 +81,16 @@ func setEnvVars(v *viper.Viper) {
 }
 
 type Configuration struct {
-	Port          int           `mapstructure:"port"`
-	AdminPort     int           `mapstructure:"admin_port"`
-	Log           Log           `mapstructure:"log"`
-	RateLimiting  RateLimiting  `mapstructure:"rate_limiter"`
-	RequestLimits RequestLimits `mapstructure:"request_limits"`
-	Backend       Backend       `mapstructure:"backend"`
-	Compression   Compression   `mapstructure:"compression"`
-	Metrics       Metrics       `mapstructure:"metrics"`
+	Port                int           `mapstructure:"port"`
+	AdminPort           int           `mapstructure:"admin_port"`
+	DefaultRouteEnabled bool          `mapstructure:"default_route_enabled"`
+	PublicWriteEnabled  bool          `mapstructure:"public_write_enabled"`
+	Log                 Log           `mapstructure:"log"`
+	RateLimiting        RateLimiting  `mapstructure:"rate_limiter"`
+	RequestLimits       RequestLimits `mapstructure:"request_limits"`
+	Backend             Backend       `mapstructure:"backend"`
+	Compression         Compression   `mapstructure:"compression"`
+	Metrics             Metrics       `mapstructure:"metrics"`
 }
 
 // ValidateAndLog validates the config, terminating the program on any errors.

--- a/config/config.go
+++ b/config/config.go
@@ -63,7 +63,7 @@ func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("request_limits.max_size_bytes", 10*1024)
 	v.SetDefault("request_limits.max_num_values", 10)
 	v.SetDefault("request_limits.max_ttl_seconds", 3600)
-	v.SetDefault("routes.index_enabled", true)
+	v.SetDefault("routes.empty_index_response", false)
 	v.SetDefault("routes.allow_public_write", true)
 }
 
@@ -264,6 +264,6 @@ func (m *PrometheusMetrics) Timeout() time.Duration {
 }
 
 type Routes struct {
-	IndexEnabled     bool `mapstructure:"index_enabled"`
-	AllowPublicWrite bool `mapstructure:"allow_public_write"`
+	EmptyIndexResponse bool `mapstructure:"empty_index_response"`
+	AllowPublicWrite   bool `mapstructure:"allow_public_write"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -28,8 +28,6 @@ func NewConfig() Configuration {
 func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("port", 2424)
 	v.SetDefault("admin_port", 2525)
-	v.SetDefault("default_route_enabled", true)
-	v.SetDefault("public_write_enabled", true)
 	v.SetDefault("log.level", "info")
 	v.SetDefault("backend.type", "memory")
 	v.SetDefault("backend.aerospike.host", "")
@@ -65,6 +63,8 @@ func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("request_limits.max_size_bytes", 10*1024)
 	v.SetDefault("request_limits.max_num_values", 10)
 	v.SetDefault("request_limits.max_ttl_seconds", 3600)
+	v.SetDefault("routes.index_enabled", true)
+	v.SetDefault("routes.allow_public_write", true)
 }
 
 func setConfigFile(v *viper.Viper) {
@@ -81,16 +81,15 @@ func setEnvVars(v *viper.Viper) {
 }
 
 type Configuration struct {
-	Port                int           `mapstructure:"port"`
-	AdminPort           int           `mapstructure:"admin_port"`
-	DefaultRouteEnabled bool          `mapstructure:"default_route_enabled"`
-	PublicWriteEnabled  bool          `mapstructure:"public_write_enabled"`
-	Log                 Log           `mapstructure:"log"`
-	RateLimiting        RateLimiting  `mapstructure:"rate_limiter"`
-	RequestLimits       RequestLimits `mapstructure:"request_limits"`
-	Backend             Backend       `mapstructure:"backend"`
-	Compression         Compression   `mapstructure:"compression"`
-	Metrics             Metrics       `mapstructure:"metrics"`
+	Port          int           `mapstructure:"port"`
+	AdminPort     int           `mapstructure:"admin_port"`
+	Log           Log           `mapstructure:"log"`
+	RateLimiting  RateLimiting  `mapstructure:"rate_limiter"`
+	RequestLimits RequestLimits `mapstructure:"request_limits"`
+	Backend       Backend       `mapstructure:"backend"`
+	Compression   Compression   `mapstructure:"compression"`
+	Metrics       Metrics       `mapstructure:"metrics"`
+	Routes        Routes        `mapstructure:"routes"`
 }
 
 // ValidateAndLog validates the config, terminating the program on any errors.
@@ -262,4 +261,9 @@ func (promMetricsConfig *PrometheusMetrics) validateAndLog() {
 
 func (m *PrometheusMetrics) Timeout() time.Duration {
 	return time.Duration(m.TimeoutMillisRaw) * time.Millisecond
+}
+
+type Routes struct {
+	IndexEnabled     bool `mapstructure:"index_enabled"`
+	AllowPublicWrite bool `mapstructure:"allow_public_write"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -105,6 +105,7 @@ func (cfg *Configuration) ValidateAndLog() {
 	cfg.Backend.validateAndLog()
 	cfg.Compression.validateAndLog()
 	cfg.Metrics.validateAndLog()
+	cfg.Routes.validateAndLog()
 }
 
 type Log struct {
@@ -266,4 +267,10 @@ func (m *PrometheusMetrics) Timeout() time.Duration {
 
 type Routes struct {
 	AllowPublicWrite bool `mapstructure:"allow_public_write"`
+}
+
+func (cfg *Routes) validateAndLog() {
+	if !cfg.AllowPublicWrite {
+		log.Infof("Main server will only accept GET requests")
+	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,7 @@ func TestDefaults(t *testing.T) {
 
 	assertIntsEqual(t, "port", cfg.Port, 2424)
 	assertIntsEqual(t, "admin_port", cfg.AdminPort, 2525)
+	assertStringsEqual(t, "index_response", cfg.IndexResponse, "This application stores short-term data for use in Prebid.")
 	assertStringsEqual(t, "log.level", string(cfg.Log.Level), "info")
 	assertStringsEqual(t, "backend.type", string(cfg.Backend.Type), "memory")
 	assertStringsEqual(t, "backend.aerospike.host", cfg.Backend.Aerospike.Host, "")
@@ -57,6 +58,7 @@ func TestDefaults(t *testing.T) {
 	assertIntsEqual(t, "request_limits.max_size_bytes", cfg.RequestLimits.MaxSize, 10*1024)
 	assertIntsEqual(t, "request_limits.max_num_values", cfg.RequestLimits.MaxNumValues, 10)
 	assertIntsEqual(t, "request_limits.max_ttl_seconds", cfg.RequestLimits.MaxTTLSeconds, 3600)
+	assertBoolsEqual(t, "routes.allow_public_write", cfg.Routes.AllowPublicWrite, true)
 }
 
 func TestSampleConfig(t *testing.T) {

--- a/endpoints/index.go
+++ b/endpoints/index.go
@@ -8,13 +8,9 @@ import (
 )
 
 //Default route for the prebid-cache
-func NewIndexHandler(emptyIndexResponse bool) func(http.ResponseWriter, *http.Request, httprouter.Params) {
+func NewIndexHandler(message string) func(http.ResponseWriter, *http.Request, httprouter.Params) {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-		if emptyIndexResponse {
-			w.WriteHeader(http.StatusNoContent)
-		} else {
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, "This application stores short-term data for use in Prebid.")
-		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, message)
 	}
 }

--- a/endpoints/index.go
+++ b/endpoints/index.go
@@ -7,10 +7,14 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
-//Handle Default route for the prebid-cache
-func Index(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	//Default routing instead of showing 404 not found error
-	// Added Default routing handler added message instead of trowing 404 Error
-	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, "This application stores short-term data for use in Prebid.")
+//Default route for the prebid-cache
+func NewIndexHandler(emptyIndexResponse bool) func(http.ResponseWriter, *http.Request, httprouter.Params) {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		if emptyIndexResponse {
+			w.WriteHeader(http.StatusNoContent)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, "This application stores short-term data for use in Prebid.")
+		}
+	}
 }

--- a/endpoints/routing/handler.go
+++ b/endpoints/routing/handler.go
@@ -35,10 +35,8 @@ func NewPublicHandler(cfg config.Configuration, dataStore backends.Backend, appM
 }
 
 func addReadRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) {
-	if cfg.Routes.IndexEnabled {
-		router.GET("/", endpoints.Index) //Default route handler
-	}
-	router.GET("/status", endpoints.Status) // Determines whether the server is ready for more traffic.
+	router.GET("/", endpoints.NewIndexHandler(cfg.Routes.EmptyIndexResponse)) //Default route handler
+	router.GET("/status", endpoints.Status)                                   // Determines whether the server is ready for more traffic.
 	router.GET("/cache", decorators.MonitorHttp(endpoints.NewGetHandler(dataStore, cfg.RequestLimits.AllowSettingKeys), appMetrics, decorators.GetMethod))
 }
 

--- a/endpoints/routing/handler.go
+++ b/endpoints/routing/handler.go
@@ -17,16 +17,16 @@ import (
 
 func NewAdminHandler(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics) http.Handler {
 	router := httprouter.New()
-	router = addReadRoutes(cfg, dataStore, appMetrics, router)
-	router = addWriteRoutes(cfg, dataStore, appMetrics, router)
+	addReadRoutes(cfg, dataStore, appMetrics, router)
+	addWriteRoutes(cfg, dataStore, appMetrics, router)
 	return router
 }
 
 func NewPublicHandler(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics) http.Handler {
 	router := httprouter.New()
-	router = addReadRoutes(cfg, dataStore, appMetrics, router)
+	addReadRoutes(cfg, dataStore, appMetrics, router)
 	if cfg.PublicWriteEnabled {
-		router = addWriteRoutes(cfg, dataStore, appMetrics, router)
+		addWriteRoutes(cfg, dataStore, appMetrics, router)
 	}
 
 	handler := handleCors(router)
@@ -34,18 +34,16 @@ func NewPublicHandler(cfg config.Configuration, dataStore backends.Backend, appM
 	return router
 }
 
-func addReadRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) *httprouter.Router {
+func addReadRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) {
 	if cfg.DefaultRouteEnabled {
 		router.GET("/", endpoints.Index) //Default route handler
 	}
 	router.GET("/status", endpoints.Status) // Determines whether the server is ready for more traffic.
 	router.GET("/cache", decorators.MonitorHttp(endpoints.NewGetHandler(dataStore, cfg.RequestLimits.AllowSettingKeys), appMetrics, decorators.GetMethod))
-	return router
 }
 
-func addWriteRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) *httprouter.Router {
+func addWriteRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) {
 	router.POST("/cache", decorators.MonitorHttp(endpoints.NewPutHandler(dataStore, cfg.RequestLimits.MaxNumValues, cfg.RequestLimits.AllowSettingKeys), appMetrics, decorators.PostMethod))
-	return router
 }
 
 func handleCors(handler http.Handler) http.Handler {

--- a/endpoints/routing/handler.go
+++ b/endpoints/routing/handler.go
@@ -25,7 +25,7 @@ func NewAdminHandler(cfg config.Configuration, dataStore backends.Backend, appMe
 func NewPublicHandler(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics) http.Handler {
 	router := httprouter.New()
 	addReadRoutes(cfg, dataStore, appMetrics, router)
-	if cfg.PublicWriteEnabled {
+	if cfg.Routes.AllowPublicWrite {
 		addWriteRoutes(cfg, dataStore, appMetrics, router)
 	}
 
@@ -35,7 +35,7 @@ func NewPublicHandler(cfg config.Configuration, dataStore backends.Backend, appM
 }
 
 func addReadRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) {
-	if cfg.DefaultRouteEnabled {
+	if cfg.Routes.IndexEnabled {
 		router.GET("/", endpoints.Index) //Default route handler
 	}
 	router.GET("/status", endpoints.Status) // Determines whether the server is ready for more traffic.

--- a/endpoints/routing/handler.go
+++ b/endpoints/routing/handler.go
@@ -15,16 +15,37 @@ import (
 	"github.com/rs/cors"
 )
 
-func NewHandler(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics) http.Handler {
+func NewAdminHandler(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics) http.Handler {
 	router := httprouter.New()
-	router.GET("/", endpoints.Index)        //Default route handler
-	router.GET("/status", endpoints.Status) // Determines whether the server is ready for more traffic.
-	router.POST("/cache", decorators.MonitorHttp(endpoints.NewPutHandler(dataStore, cfg.RequestLimits.MaxNumValues, cfg.RequestLimits.AllowSettingKeys), appMetrics, decorators.PostMethod))
-	router.GET("/cache", decorators.MonitorHttp(endpoints.NewGetHandler(dataStore, cfg.RequestLimits.AllowSettingKeys), appMetrics, decorators.GetMethod))
+	router = addReadOnlyRoutes(cfg, dataStore, appMetrics, router)
+	router = addWriteRoutes(cfg, dataStore, appMetrics, router)
+	return router
+}
+
+func NewPublicHandler(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics) http.Handler {
+	router := httprouter.New()
+	router = addReadOnlyRoutes(cfg, dataStore, appMetrics, router)
+	if cfg.PublicWriteEnabled {
+		router = addWriteRoutes(cfg, dataStore, appMetrics, router)
+	}
 
 	handler := handleCors(router)
 	handler = handleRateLimiting(handler, cfg.RateLimiting)
-	return handler
+	return router
+}
+
+func addReadOnlyRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) *httprouter.Router {
+	if cfg.DefaultRouteEnabled {
+		router.GET("/", endpoints.Index) //Default route handler
+	}
+	router.GET("/status", endpoints.Status) // Determines whether the server is ready for more traffic.
+	router.GET("/cache", decorators.MonitorHttp(endpoints.NewGetHandler(dataStore, cfg.RequestLimits.AllowSettingKeys), appMetrics, decorators.GetMethod))
+	return router
+}
+
+func addWriteRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) *httprouter.Router {
+	router.POST("/cache", decorators.MonitorHttp(endpoints.NewPutHandler(dataStore, cfg.RequestLimits.MaxNumValues, cfg.RequestLimits.AllowSettingKeys), appMetrics, decorators.PostMethod))
+	return router
 }
 
 func handleCors(handler http.Handler) http.Handler {

--- a/endpoints/routing/handler.go
+++ b/endpoints/routing/handler.go
@@ -17,14 +17,14 @@ import (
 
 func NewAdminHandler(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics) http.Handler {
 	router := httprouter.New()
-	router = addReadOnlyRoutes(cfg, dataStore, appMetrics, router)
+	router = addReadRoutes(cfg, dataStore, appMetrics, router)
 	router = addWriteRoutes(cfg, dataStore, appMetrics, router)
 	return router
 }
 
 func NewPublicHandler(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics) http.Handler {
 	router := httprouter.New()
-	router = addReadOnlyRoutes(cfg, dataStore, appMetrics, router)
+	router = addReadRoutes(cfg, dataStore, appMetrics, router)
 	if cfg.PublicWriteEnabled {
 		router = addWriteRoutes(cfg, dataStore, appMetrics, router)
 	}
@@ -34,7 +34,7 @@ func NewPublicHandler(cfg config.Configuration, dataStore backends.Backend, appM
 	return router
 }
 
-func addReadOnlyRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) *httprouter.Router {
+func addReadRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) *httprouter.Router {
 	if cfg.DefaultRouteEnabled {
 		router.GET("/", endpoints.Index) //Default route handler
 	}

--- a/endpoints/routing/handler.go
+++ b/endpoints/routing/handler.go
@@ -35,8 +35,8 @@ func NewPublicHandler(cfg config.Configuration, dataStore backends.Backend, appM
 }
 
 func addReadRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) {
-	router.GET("/", endpoints.NewIndexHandler(cfg.Routes.EmptyIndexResponse)) //Default route handler
-	router.GET("/status", endpoints.Status)                                   // Determines whether the server is ready for more traffic.
+	router.GET("/", endpoints.NewIndexHandler(cfg.Routes.IndexResponse)) //Default route handler
+	router.GET("/status", endpoints.Status)                              // Determines whether the server is ready for more traffic.
 	router.GET("/cache", decorators.MonitorHttp(endpoints.NewGetHandler(dataStore, cfg.RequestLimits.AllowSettingKeys), appMetrics, decorators.GetMethod))
 }
 

--- a/endpoints/routing/handler.go
+++ b/endpoints/routing/handler.go
@@ -31,7 +31,7 @@ func NewPublicHandler(cfg config.Configuration, dataStore backends.Backend, appM
 
 	handler := handleCors(router)
 	handler = handleRateLimiting(handler, cfg.RateLimiting)
-	return router
+	return handler
 }
 
 func addReadRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) {

--- a/endpoints/routing/handler.go
+++ b/endpoints/routing/handler.go
@@ -35,8 +35,8 @@ func NewPublicHandler(cfg config.Configuration, dataStore backends.Backend, appM
 }
 
 func addReadRoutes(cfg config.Configuration, dataStore backends.Backend, appMetrics *metrics.Metrics, router *httprouter.Router) {
-	router.GET("/", endpoints.NewIndexHandler(cfg.Routes.IndexResponse)) //Default route handler
-	router.GET("/status", endpoints.Status)                              // Determines whether the server is ready for more traffic.
+	router.GET("/", endpoints.NewIndexHandler(cfg.IndexResponse)) //Default route handler
+	router.GET("/status", endpoints.Status)                       // Determines whether the server is ready for more traffic.
 	router.GET("/cache", decorators.MonitorHttp(endpoints.NewGetHandler(dataStore, cfg.RequestLimits.AllowSettingKeys), appMetrics, decorators.GetMethod))
 }
 

--- a/main.go
+++ b/main.go
@@ -21,9 +21,10 @@ func main() {
 
 	appMetrics := metrics.CreateMetrics(cfg)
 	backend := backendConfig.NewBackend(cfg, appMetrics)
-	handler := routing.NewHandler(cfg, backend, appMetrics)
+	publicHandler := routing.NewPublicHandler(cfg, backend, appMetrics)
+	adminHandler := routing.NewAdminHandler(cfg, backend, appMetrics)
 	go appMetrics.Export(cfg)
-	server.Listen(cfg, handler, appMetrics)
+	server.Listen(cfg, publicHandler, adminHandler, appMetrics)
 }
 
 func setLogLevel(logLevel config.LogLevel) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -13,7 +13,7 @@ func TestNewAdminServer(t *testing.T) {
 		Port:      8000,
 		AdminPort: 6060,
 	}
-	server := newAdminServer(cfg)
+	server := newAdminServer(cfg, http.HandlerFunc(handler))
 	if server.Addr != ":6060" {
 		t.Errorf("Admin server address should be %s. Got %s", ":6060", server.Addr)
 	}


### PR DESCRIPTION
We intend on using prebid-cache to cache responses from a backend, and hand out the urls to the cache for the frontend clients to consume. prebid-cache currently exposes both the POST and the GET for cache items to the public API, which is not ideal if we never want the public to be able to write to our cache.

This change:
- Adds configuration `routes.allow_public_write` to disable writes on the public port (2424 default)
- Adds a read/write not rate limited handler into the API for the admin port (2525 default)
- Adds configuration `routes.index_response` to change the messaging on the `/` response

Related to https://github.com/prebid/prebid-cache/issues/36 which is asking for this functionality.

Tested it locally with the various flags on/off using CURL and it seems to work fine, existing tests are happy but they do not seem to cover much re: poking actual urls.