### PR TITLE
Remove "Aerospike" string from Aerospike backend error messages

### DIFF
--- a/backends/aerospike.go
+++ b/backends/aerospike.go
@@ -127,10 +127,10 @@ func formatAerospikeError(err error) error {
 	if err != nil {
 		if aerr, ok := err.(as_types.AerospikeError); ok {
 			if aerr.ResultCode() == as_types.KEY_NOT_FOUND_ERROR {
-				return KeyNotFoundError{"Aerospike"}
+				return KeyNotFoundError{}
 			}
 		}
-		return errors.New("Aerospike " + err.Error())
+		return errors.New(err.Error())
 	}
 	return err
 }

--- a/backends/aerospike_test.go
+++ b/backends/aerospike_test.go
@@ -115,7 +115,7 @@ func TestNewAerospikeBackend(t *testing.T) {
 			expectedLogEntries: []logEntry{
 
 				{
-					msg: "Aerospike Failed to connect to host(s): [foo.com:8888 bat.com:8888]; error: Connecting to the cluster timed out.",
+					msg: "Failed to connect to host(s): [foo.com:8888 bat.com:8888]; error: Connecting to the cluster timed out.",
 					lvl: logrus.FatalLevel,
 				},
 			},
@@ -134,7 +134,7 @@ func TestNewAerospikeBackend(t *testing.T) {
 					lvl: logrus.InfoLevel,
 				},
 				{
-					msg: "Aerospike Failed to connect to host(s): [fakeTestUrl.foo:8888 foo.com:8888 bat.com:8888]; error: Connecting to the cluster timed out.",
+					msg: "Failed to connect to host(s): [fakeTestUrl.foo:8888 foo.com:8888 bat.com:8888]; error: Connecting to the cluster timed out.",
 					lvl: logrus.FatalLevel,
 				},
 			},
@@ -152,7 +152,7 @@ func TestNewAerospikeBackend(t *testing.T) {
 					lvl: logrus.InfoLevel,
 				},
 				{
-					msg: "Aerospike Failed to connect to host(s): [fakeTestUrl.foo:8888]; error: Connecting to the cluster timed out.",
+					msg: "Failed to connect to host(s): [fakeTestUrl.foo:8888]; error: Connecting to the cluster timed out.",
 					lvl: logrus.FatalLevel,
 				},
 			},
@@ -196,27 +196,27 @@ func TestFormatAerospikeError(t *testing.T) {
 		{
 			desc:        "Non-nil error, print without a caller",
 			inErr:       fmt.Errorf("client.Get returned nil record"),
-			expectedErr: fmt.Errorf("Aerospike client.Get returned nil record"),
+			expectedErr: fmt.Errorf("client.Get returned nil record"),
 		},
 		{
 			desc:        "Non-nil error, comes with a caller",
 			inErr:       fmt.Errorf("client.Get returned nil record"),
-			expectedErr: fmt.Errorf("Aerospike client.Get returned nil record"),
+			expectedErr: fmt.Errorf("client.Get returned nil record"),
 		},
 		{
 			desc:        "Non-nil error, comes with more than one callers",
 			inErr:       fmt.Errorf("client.Get returned nil record"),
-			expectedErr: fmt.Errorf("Aerospike client.Get returned nil record"),
+			expectedErr: fmt.Errorf("client.Get returned nil record"),
 		},
 		{
 			desc:        "Aerospike error, comes with a caller",
 			inErr:       as_types.NewAerospikeError(as_types.SERVER_NOT_AVAILABLE),
-			expectedErr: fmt.Errorf("Aerospike Server is not accepting requests."),
+			expectedErr: fmt.Errorf("Server is not accepting requests."),
 		},
 		{
 			desc:        "Aerospike KEY_NOT_FOUND_ERROR error, attach our GetKeyNotFound constant",
 			inErr:       as_types.NewAerospikeError(as_types.KEY_NOT_FOUND_ERROR),
-			expectedErr: fmt.Errorf("Aerospike Key not found"),
+			expectedErr: fmt.Errorf("Key not found"),
 		},
 	}
 	for _, test := range testCases {
@@ -245,31 +245,31 @@ func TestClientGet(t *testing.T) {
 			desc:              "AerospikeBackend.Get() throws error when trying to generate new key",
 			inAerospikeClient: NewErrorProneAerospikeClient("TEST_KEY_GEN_ERROR"),
 			expectedValue:     "",
-			expectedErrorMsg:  "Aerospike Not authenticated",
+			expectedErrorMsg:  "Not authenticated",
 		},
 		{
 			desc:              "AerospikeBackend.Get() throws error when 'client.Get(..)' gets called",
 			inAerospikeClient: NewErrorProneAerospikeClient("TEST_GET_ERROR"),
 			expectedValue:     "",
-			expectedErrorMsg:  "Aerospike Key not found",
+			expectedErrorMsg:  "Key not found",
 		},
 		{
 			desc:              "AerospikeBackend.Get() throws error when 'client.Get(..)' returns a nil record",
 			inAerospikeClient: NewErrorProneAerospikeClient("TEST_NIL_RECORD_ERROR"),
 			expectedValue:     "",
-			expectedErrorMsg:  "Aerospike Nil record",
+			expectedErrorMsg:  "Nil record",
 		},
 		{
 			desc:              "AerospikeBackend.Get() throws error no BIN_VALUE bucket is found",
 			inAerospikeClient: NewErrorProneAerospikeClient("TEST_NO_BUCKET_ERROR"),
 			expectedValue:     "",
-			expectedErrorMsg:  "Aerospike No 'value' bucket found",
+			expectedErrorMsg:  "No 'value' bucket found",
 		},
 		{
 			desc:              "AerospikeBackend.Get() returns a record that does not store a string",
 			inAerospikeClient: NewErrorProneAerospikeClient("TEST_NON_STRING_VALUE_ERROR"),
 			expectedValue:     "",
-			expectedErrorMsg:  "Aerospike Unexpected non-string value found",
+			expectedErrorMsg:  "Unexpected non-string value found",
 		},
 		{
 			desc:              "AerospikeBackend.Get() does not throw error",
@@ -317,7 +317,7 @@ func TestClientPut(t *testing.T) {
 			inKey:             "testKey",
 			inValueToStore:    "not default value",
 			expectedStoredVal: "",
-			expectedErrorMsg:  "Aerospike Not authenticated",
+			expectedErrorMsg:  "Not authenticated",
 		},
 		{
 			desc:              "AerospikeBackend.Put() throws error when 'client.Put(..)' gets called",
@@ -325,7 +325,7 @@ func TestClientPut(t *testing.T) {
 			inKey:             "testKey",
 			inValueToStore:    "not default value",
 			expectedStoredVal: "",
-			expectedErrorMsg:  "Aerospike Key already exists",
+			expectedErrorMsg:  "Key already exists",
 		},
 		{
 			desc:              "AerospikeBackend.Put() does not throw error",

--- a/backends/errors.go
+++ b/backends/errors.go
@@ -1,9 +1,7 @@
 package backends
 
-type KeyNotFoundError struct {
-	msgPrefix string
-}
+type KeyNotFoundError struct{}
 
 func (e KeyNotFoundError) Error() string {
-	return e.msgPrefix + " Key not found"
+	return "Key not found"
 }

--- a/endpoints/integration_test.go
+++ b/endpoints/integration_test.go
@@ -236,10 +236,10 @@ func TestGetHandler(t *testing.T) {
 			testInput{uuid: "uuid-not-found-and-links-to-no-value"},
 			testOutput{
 				responseCode: http.StatusNotFound,
-				responseBody: "GET /cache uuid=uuid-not-found-and-links-to-no-value:  Key not found\n",
+				responseBody: "GET /cache uuid=uuid-not-found-and-links-to-no-value: Key not found\n",
 				logEntries: []logEntry{
 					{
-						msg: "GET /cache uuid=uuid-not-found-and-links-to-no-value:  Key not found",
+						msg: "GET /cache uuid=uuid-not-found-and-links-to-no-value: Key not found",
 						lvl: logrus.DebugLevel,
 					},
 				},


### PR DESCRIPTION
Prebid Cache is able use of a number of back-end systems. We rather not identify the back-end system (Aerospike, Redis, Cassandra or Azure) in the error messages whenever they come up. This pull request removes the "Aerospike" string from any error message the Aerospike back-end may throw.