### PR TITLE
Correct payload size limit

### DIFF
--- a/backends/config/config.go
+++ b/backends/config/config.go
@@ -12,13 +12,13 @@ import (
 
 func NewBackend(cfg config.Configuration, appMetrics *metrics.Metrics) backends.Backend {
 	backend := newBaseBackend(cfg.Backend, appMetrics)
+	backend = applyCompression(cfg.Compression, backend)
 	if cfg.RequestLimits.MaxSize > 0 {
 		backend = decorators.EnforceSizeLimit(backend, cfg.RequestLimits.MaxSize)
 	}
 	// Metrics must be taken _before_ compression because it relies on the
 	// "json" or "xml" prefix on the payload. Compression might munge this.
 	// We should re-work this strategy at some point.
-	backend = applyCompression(cfg.Compression, backend)
 	backend = decorators.LogMetrics(backend, appMetrics)
 	backend = decorators.LimitTTLs(backend, getMaxTTLSeconds(cfg))
 	return backend


### PR DESCRIPTION
The config option `request_limits.max_size_bytes` caps the maximum size of the `request.puts[i].value` fields but if Prebid Cache was configured to compress data (`config.compression.type` set to `snappy`) elements bigger than `request_limits.max_size_bytes` may still pass validation because they get compressed before getting checked.

This pull request corrects the aforementioned bug by swapping the order in which the decorators get assigned to wrap the data store backend.
