### PR TITLE
Rolledback uppercase in MISSING_KEY type errors

### DIFF
--- a/endpoints/get_test.go
+++ b/endpoints/get_test.go
@@ -67,10 +67,10 @@ func TestGetHandler(t *testing.T) {
 			},
 			testOutput{
 				responseCode: http.StatusBadRequest,
-				responseBody: "GET /cache: missing required parameter uuid\n",
+				responseBody: "GET /cache: Missing required parameter uuid\n",
 				logEntries: []logEntry{
 					{
-						msg: "GET /cache: missing required parameter uuid",
+						msg: "GET /cache: Missing required parameter uuid",
 						lvl: logrus.ErrorLevel,
 					},
 				},

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -49,7 +49,7 @@ var errToStatusCodes map[int]int = map[int]int{
 // Not all error types are found here since some of them have non-constant error messages and
 // are assigned custom messages upon creation
 var errToMsgs map[int]string = map[int]string{
-	MISSING_KEY:              "missing required parameter uuid",
+	MISSING_KEY:              "Missing required parameter uuid",
 	RECORD_EXISTS:            "Record exists with provided key.",
 	MISSING_VALUE:            "Missing value.",
 	UNKNOWN_STORED_DATA_TYPE: "Cache data was corrupted. Cannot determine type.",

--- a/utils/errors_test.go
+++ b/utils/errors_test.go
@@ -25,7 +25,7 @@ func TestPBCError(t *testing.T) {
 			expected: PBCError{
 				Type:       MISSING_KEY,
 				StatusCode: http.StatusBadRequest,
-				msg:        "missing required parameter uuid",
+				msg:        "Missing required parameter uuid",
 			},
 		},
 		{


### PR DESCRIPTION
Eventually we may want to correct the error messages but for the moment let's roll back the capitalization of the first letter of the `MISSING_KEY` type error messages.