### PR TITLE
Bug fix. Displaying wrong error messages

### DIFF
--- a/endpoints/put.go
+++ b/endpoints/put.go
@@ -271,6 +271,7 @@ func (e *PutHandler) put(po *putObject, resp *putResponseObject, index int, wg *
 	toCache, err := parsePutObject(*po)
 	if err != nil {
 		resp.err = err
+		return
 	}
 
 	// Only allow setting a provided key if configured (and ensure a key is provided).

--- a/endpoints/put_test.go
+++ b/endpoints/put_test.go
@@ -498,7 +498,7 @@ func TestTooManyPutElements(t *testing.T) {
 
 	putResponse := doPut(t, router, reqBody)
 
-	assert.Equalf(t, http.StatusBadRequest, putResponse.Code, "doMockPut should have failed when trying to store %d elements because capacity is %d ", len(putElements), len(putElements)-1)
+	assert.Equalf(t, http.StatusBadRequest, putResponse.Code, "doPut should have failed when trying to store %d elements because capacity is %d ", len(putElements), len(putElements)-1)
 	assert.Equal(t, "More keys than allowed: 2\n", putResponse.Body.String(), "Put() return error doesn't match expected.")
 
 	backend.AssertNotCalled(t, "Put")
@@ -601,7 +601,7 @@ func TestBadPayloadSizePutError(t *testing.T) {
 	putResponse := doPut(t, router, reqBody)
 
 	// Assert expected response
-	assert.Equal(t, http.StatusBadRequest, putResponse.Code, "doMockPut should have failed when trying to store elements in sizeCappedBackend")
+	assert.Equal(t, http.StatusBadRequest, putResponse.Code, "doPut should have failed when trying to store elements in sizeCappedBackend")
 	assert.Equal(t, "POST /cache element 0 exceeded max size: Payload size 30 exceeded max 3\n", putResponse.Body.String(), "Put() return error doesn't match expected.")
 
 	//   metrics

--- a/endpoints/put_test.go
+++ b/endpoints/put_test.go
@@ -169,29 +169,38 @@ func TestSuccessfulPut(t *testing.T) {
 			router.GET("/cache", NewGetHandler(backend, m, true))
 
 			// Feed the tests input put request to the endpoint's handle
-			uuid, putTrace := doMockPut(t, router, tc.inPutBody)
-			if !assert.Equal(t, http.StatusOK, putTrace.Code, "%s - %s: Put() call failed. Status: %d, Msg: %v", group.groupDesc, tc.desc, putTrace.Code, putTrace.Body.String()) {
+			putResponse := doMockPut(t, router, tc.inPutBody)
+			if !assert.Equal(t, http.StatusOK, putResponse.Code, "%s - %s: Put() call failed. Status: %d, Msg: %v", group.groupDesc, tc.desc, putResponse.Code, putResponse.Body.String()) {
 				return
 			}
 
-			// assert the put call above acurately stored the expected test data.
-			getResults := doMockGet(t, router, uuid)
-			if !assert.Equal(t, http.StatusOK, getResults.Code, "%s - %s: Get() failed with status: %d", group.groupDesc, tc.desc, getResults.Code) {
-				return
-			}
-			if !assert.Equal(t, tc.expectedStoredValue, getResults.Body.String(), "%s - %s: Put() call didn't store the expected value", group.groupDesc, tc.desc) {
-				return
-			}
-			if getResults.Header().Get("Content-Type") != group.expectedResponseType {
-				t.Fatalf("%s - %s: Expected GET response Content-Type %v to equal %v", group.groupDesc, tc.desc, getResults.Header().Get("Content-Type"), group.expectedResponseType)
+			// Response was a 200, extract responses
+			var parsed PutResponse
+			err := json.Unmarshal(putResponse.Body.Bytes(), &parsed)
+			assert.NoError(t, err, "Response from POST doesn't conform to the expected format: %s", putResponse.Body.String())
+
+			// Assert responses
+			for _, putResponse := range parsed.Responses {
+				// assert the put call above acurately stored the expected test data.
+				getResults := doMockGet(t, router, putResponse.UUID)
+				if !assert.Equal(t, http.StatusOK, getResults.Code, "%s - %s: Get() failed with status: %d", group.groupDesc, tc.desc, getResults.Code) {
+					return
+				}
+				if !assert.Equal(t, tc.expectedStoredValue, getResults.Body.String(), "%s - %s: Put() call didn't store the expected value", group.groupDesc, tc.desc) {
+					return
+				}
+				if getResults.Header().Get("Content-Type") != group.expectedResponseType {
+					t.Fatalf("%s - %s: Expected GET response Content-Type %v to equal %v", group.groupDesc, tc.desc, getResults.Header().Get("Content-Type"), group.expectedResponseType)
+				}
+
+				// assert the put call above logged expected metrics
+				assert.Equal(t, tc.expectedMetrics.totalRequests, metricstest.MockCounters["puts.current_url.request.total"], "%s - handle function should record every incomming PUT request", tc.desc)
+				assert.Equal(t, tc.expectedMetrics.keyWasProvided, metricstest.MockCounters["puts.current_url.request.custom_key"], "%s - custom key was provided for put request and was not accounted for", tc.desc)
+				assert.Equal(t, tc.expectedMetrics.badRequests, metricstest.MockCounters["puts.current_url.request.bad_request"], "%s - Bad request wasn't recorded", tc.desc)
+				assert.Equal(t, tc.expectedMetrics.requestErrs, metricstest.MockCounters["puts.current_url.request.error"], "%s - WriteGetResponse error should have been recorded", tc.desc)
+				assert.Equal(t, tc.expectedMetrics.requestDur, metricstest.MockHistograms["puts.current_url.duration"], "%s - Successful GET request should have recorded duration", tc.desc)
 			}
 
-			// assert the put call above logged expected metrics
-			assert.Equal(t, tc.expectedMetrics.totalRequests, metricstest.MockCounters["puts.current_url.request.total"], "%s - handle function should record every incomming PUT request", tc.desc)
-			assert.Equal(t, tc.expectedMetrics.keyWasProvided, metricstest.MockCounters["puts.current_url.request.custom_key"], "%s - custom key was provided for put request and was not accounted for", tc.desc)
-			assert.Equal(t, tc.expectedMetrics.badRequests, metricstest.MockCounters["puts.current_url.request.bad_request"], "%s - Bad request wasn't recorded", tc.desc)
-			assert.Equal(t, tc.expectedMetrics.requestErrs, metricstest.MockCounters["puts.current_url.request.error"], "%s - WriteGetResponse error should have been recorded", tc.desc)
-			assert.Equal(t, tc.expectedMetrics.requestDur, metricstest.MockHistograms["puts.current_url.duration"], "%s - Successful GET request should have recorded duration", tc.desc)
 		}
 	}
 }
@@ -208,65 +217,81 @@ func TestMalformedOrInvalidValue(t *testing.T) {
 	}
 
 	testCases := []struct {
-		desc            string
-		inPutBody       string
-		expectedMetrics metricRecords
+		desc             string
+		inPutBody        string
+		expectedMetrics  metricRecords
+		expectedError    error
+		expectedPutCalls int
 	}{
 		{
-			"Badly escaped character in value field",
-			"{\"puts\":[{\"type\":\"json\",\"value\":\"badly-esca\"ped\"}]}",
-			metricRecords{
+			desc:      "Badly escaped character in value field",
+			inPutBody: "{\"puts\":[{\"type\":\"json\",\"value\":\"badly-esca\"ped\"}]}",
+			expectedMetrics: metricRecords{
 				totalRequests: int64(1),
 				badRequests:   int64(1),
 			},
+			expectedError:    utils.NewPBCError(utils.PUT_BAD_REQUEST, "{\"puts\":[{\"type\":\"json\",\"value\":\"badly-esca\"ped\"}]}"),
+			expectedPutCalls: 0,
 		},
 		{
-			"Malformed JSON in value field",
-			"{\"puts\":[{\"type\":\"json\",\"value\":malformed}]}",
-			metricRecords{
+			desc:      "Malformed JSON in value field",
+			inPutBody: "{\"puts\":[{\"type\":\"json\",\"value\":malformed}]}",
+			expectedMetrics: metricRecords{
 				totalRequests: int64(1),
 				badRequests:   int64(1),
 			},
+			expectedError:    utils.NewPBCError(utils.PUT_BAD_REQUEST, "{\"puts\":[{\"type\":\"json\",\"value\":malformed}]}"),
+			expectedPutCalls: 0,
 		},
 		{
-			"Missing value field in sole element of puts array",
-			"{\"puts\":[{\"type\":\"json\",\"unrecognized\":true}]}",
-			metricRecords{
+			desc:      "Missing value field in sole element of puts array",
+			inPutBody: "{\"puts\":[{\"type\":\"json\",\"unrecognized\":true}]}",
+			expectedMetrics: metricRecords{
 				totalRequests: int64(1),
 				badRequests:   int64(1),
 			},
+			expectedError:    utils.NewPBCError(utils.MISSING_VALUE),
+			expectedPutCalls: 0,
 		},
 		{
-			"Missing value field in at least one element of puts array",
-			"{\"puts\":[{\"type\":\"json\",\"value\":true}, {\"type\":\"json\",\"unrecognized\":true}]}",
-			metricRecords{
+			desc:      "Missing value field in at least one element of puts array",
+			inPutBody: "{\"puts\":[{\"type\":\"json\",\"value\":true}, {\"type\":\"json\",\"unrecognized\":true}]}",
+			expectedMetrics: metricRecords{
 				totalRequests: int64(1),
 				badRequests:   int64(1),
 			},
+			expectedError:    utils.NewPBCError(utils.MISSING_VALUE),
+			expectedPutCalls: 1,
 		},
 		{
-			"Invalid XML",
-			"{\"puts\":[{\"type\":\"xml\",\"value\":5}]}",
-			metricRecords{
+			desc:      "Invalid XML",
+			inPutBody: "{\"puts\":[{\"type\":\"xml\",\"value\":5}]}",
+			expectedMetrics: metricRecords{
 				totalRequests: int64(1),
 				badRequests:   int64(1),
 			},
+			expectedError:    utils.NewPBCError(utils.MALFORMED_XML, "XML messages must have a String value. Found [53]"),
+			expectedPutCalls: 0,
 		},
 	}
 
 	for _, tc := range testCases {
 		// setup test
 		router := httprouter.New()
-		backend := backends.NewMemoryBackend()
+		backend := newCountingCallsBackend()
 		m := metricstest.CreateMockMetrics()
 
 		router.POST("/cache", NewPutHandler(backend, m, 10, true))
 
 		// Run test
-		_, putTrace := doMockPut(t, router, tc.inPutBody)
+		putResponse := doMockPut(t, router, tc.inPutBody)
 
-		// Assert
-		assert.Equal(t, http.StatusBadRequest, putTrace.Code, "%s: Put() call expected 400 response. Got: %d, Msg: %v", tc.desc, putTrace.Code, putTrace.Body.String())
+		// Assert expected response
+		assert.Equal(t, http.StatusBadRequest, putResponse.Code, "%s: Put() call expected 400 response. Got: %d, Msg: %v", tc.desc, putResponse.Code, putResponse.Body.String())
+		assert.Equal(t, tc.expectedError.Error()+"\n", putResponse.Body.String(), "%s: Put() return error doesn't match expected.", tc.desc)
+
+		// Assert Put was not called
+		assert.Equal(t, tc.expectedPutCalls, backend.PutCalls, "%s: Should have been discarded in the validation stage and not call put.", tc.desc)
 
 		// assert the put call above logged expected metrics
 		assert.Equal(t, tc.expectedMetrics.totalRequests, metricstest.MockCounters["puts.current_url.request.total"], "%s - handle function should record every incomming PUT request", tc.desc)
@@ -283,16 +308,24 @@ func TestMalformedOrInvalidValue(t *testing.T) {
 func TestNonSupportedType(t *testing.T) {
 	requestBody := "{\"puts\":[{\"type\":\"yaml\",\"value\":\"<tag></tag>\"}]}"
 
-	backend := backends.NewMemoryBackend()
+	backend := newCountingCallsBackend()
 	router := httprouter.New()
 	m := metricstest.CreateMockMetrics()
 	router.POST("/cache", NewPutHandler(backend, m, 10, true))
 
-	_, putTrace := doMockPut(t, router, requestBody)
-	if putTrace.Code != http.StatusBadRequest {
-		t.Fatalf("Expected 400 response. Got: %d, Msg: %v", putTrace.Code, putTrace.Body.String())
+	putResponse := doMockPut(t, router, requestBody)
+
+	// Assert expected response
+	if !assert.Equal(t, http.StatusBadRequest, putResponse.Code, "Expected 400 response. Got: %d, Msg: %v", putResponse.Code, putResponse.Body.String()) {
 		return
 	}
+	if !assert.Equal(t, "Type must be one of [\"json\", \"xml\"]. Found yaml\n", putResponse.Body.String(), "Put() return error doesn't match expected.") {
+		return
+	}
+
+	// Assert Put was not called
+	assert.Equal(t, 0, backend.PutCalls, "Should have been discarded in the validation stage and not call put.")
+
 	// assert the put call above logged expected metrics
 	assert.Equal(t, int64(1), metricstest.MockCounters["puts.current_url.request.total"], "Handle function should record every incomming PUT request")
 	assert.Equal(t, int64(0), metricstest.MockCounters["puts.current_url.request.custom_key"], "Custom key was provided for put request and was not accounted for")
@@ -489,13 +522,19 @@ func TestTooManyPutElements(t *testing.T) {
 	reqBody := fmt.Sprintf("{\"puts\":[%s, %s, %s]}", putElements[0], putElements[1], putElements[2])
 
 	//Set up server with capacity to handle less than putElements.size()
-	backend := backends.NewMemoryBackend()
+	backend := newCountingCallsBackend()
 	router := httprouter.New()
 	m := metricstest.CreateMockMetrics()
 	router.POST("/cache", NewPutHandler(backend, m, len(putElements)-1, true))
 
-	_, httpTestRecorder := doMockPut(t, router, reqBody)
-	assert.Equalf(t, http.StatusBadRequest, httpTestRecorder.Code, "doMockPut should have failed when trying to store %d elements because capacity is %d ", len(putElements), len(putElements)-1)
+	putResponse := doMockPut(t, router, reqBody)
+
+	// Assert expected response
+	assert.Equalf(t, http.StatusBadRequest, putResponse.Code, "doMockPut should have failed when trying to store %d elements because capacity is %d ", len(putElements), len(putElements)-1)
+	assert.Equal(t, "More keys than allowed: 2\n", putResponse.Body.String(), "Put() return error doesn't match expected.")
+
+	// Assert Put was not called
+	assert.Equal(t, 0, backend.PutCalls, "Should have been discarded in the validation stage and not call put.")
 
 	// assert the put call above logged expected metrics
 	assert.Equal(t, int64(1), metricstest.MockCounters["puts.current_url.request.total"], "Handle function should record every incomming PUT request")
@@ -593,10 +632,12 @@ func TestBadPayloadSizePutError(t *testing.T) {
 	m := metricstest.CreateMockMetrics()
 	router.POST("/cache", NewPutHandler(backend, m, 10, true))
 
-	_, httpTestRecorder := doMockPut(t, router, reqBody)
+	putResponse := doMockPut(t, router, reqBody)
 
-	// Assert status code
-	assert.Equal(t, http.StatusBadRequest, httpTestRecorder.Code, "doMockPut should have failed when trying to store elements in sizeCappedBackend")
+	// Assert expected response
+	assert.Equal(t, http.StatusBadRequest, putResponse.Code, "doMockPut should have failed when trying to store elements in sizeCappedBackend")
+	assert.Equal(t, "POST /cache element 0 exceeded max size: Payload size 30 exceeded max 3\n", putResponse.Body.String(), "Put() return error doesn't match expected.")
+
 	//   metrics
 	assert.Equal(t, int64(1), metricstest.MockCounters["puts.current_url.request.total"], "Handle function should record every incomming PUT request")
 	assert.Equal(t, int64(0), metricstest.MockCounters["puts.current_url.request.custom_key"], "Custom key was provided for put request and was not accounted for")
@@ -607,7 +648,7 @@ func TestBadPayloadSizePutError(t *testing.T) {
 
 func TestInternalPutClientError(t *testing.T) {
 	// Valid request
-	reqBody := "{\"puts\":[{\"type\":\"xml\",\"value\":\"text longer than size limit\"}]}"
+	reqBody := "{\"puts\":[{\"type\":\"xml\",\"value\":\"some data\"}]}"
 
 	// Use mock client that will return an error
 	backend := newErrorReturningBackend()
@@ -617,10 +658,12 @@ func TestInternalPutClientError(t *testing.T) {
 	m := metricstest.CreateMockMetrics()
 	router.POST("/cache", NewPutHandler(backend, m, 10, true))
 
-	_, httpTestRecorder := doMockPut(t, router, reqBody)
+	putResponse := doMockPut(t, router, reqBody)
 
-	// Assert status code
-	assert.Equal(t, http.StatusInternalServerError, httpTestRecorder.Code, "Put should have failed because we are using an MockReturnErrorBackend")
+	// Assert expected response
+	assert.Equal(t, http.StatusInternalServerError, putResponse.Code, "Put should have failed because we are using an MockReturnErrorBackend")
+	assert.Equal(t, "This is a mock backend that returns this error on Put() operation\n", putResponse.Body.String(), "Put() return error doesn't match expected.")
+
 	//   metrics
 	assert.Equal(t, int64(1), metricstest.MockCounters["puts.current_url.request.total"], "Handle function should record every incomming PUT request")
 	assert.Equal(t, int64(0), metricstest.MockCounters["puts.current_url.request.custom_key"], "Custom key was provided for put request and was not accounted for")
@@ -717,7 +760,7 @@ func TestEmptyPutRequests(t *testing.T) {
 
 func TestPutClientDeadlineExceeded(t *testing.T) {
 	// Valid request
-	reqBody := "{\"puts\":[{\"type\":\"xml\",\"value\":\"text longer than size limit\"}]}"
+	reqBody := "{\"puts\":[{\"type\":\"xml\",\"value\":\"some data\"}]}"
 
 	// Use mock client that will return an error
 	backend := newDeadlineExceededBackend()
@@ -727,10 +770,12 @@ func TestPutClientDeadlineExceeded(t *testing.T) {
 	m := metricstest.CreateMockMetrics()
 	router.POST("/cache", NewPutHandler(backend, m, 10, true))
 
-	_, httpTestRecorder := doMockPut(t, router, reqBody)
+	putResponse := doMockPut(t, router, reqBody)
 
-	// Assert status code
-	assert.Equal(t, utils.HTTPDependencyTimeout, httpTestRecorder.Code, "Put should have failed because we are using a MockDeadlineExceededBackend")
+	// Assert expected response
+	assert.Equal(t, utils.HTTPDependencyTimeout, putResponse.Code, "Put should have failed because we are using a MockDeadlineExceededBackend")
+	assert.Equal(t, "timeout writing value to the backend.\n", putResponse.Body.String(), "Put() return error doesn't match expected.")
+
 	// Assert this request is accounted under the "puts.current_url.request.error" metrics
 	assert.Equal(t, int64(1), metricstest.MockCounters["puts.current_url.request.total"], "Handle function should record every incomming PUT request")
 	assert.Equal(t, int64(0), metricstest.MockCounters["puts.current_url.request.custom_key"], "Custom key was provided for put request and was not accounted for")
@@ -989,30 +1034,17 @@ func doMockGet(t *testing.T, router *httprouter.Router, id string) *httptest.Res
 	return requestRecorder
 }
 
-func doMockPut(t *testing.T, router *httprouter.Router, content string) (string, *httptest.ResponseRecorder) {
-	var parseMockUUID = func(t *testing.T, putResponse string) string {
-		var parsed PutResponse
-		err := json.Unmarshal([]byte(putResponse), &parsed)
-		if err != nil {
-			t.Errorf("Response from POST doesn't conform to the expected format: %v", putResponse)
-		}
-		return parsed.Responses[0].UUID
-	}
-
+func doMockPut(t *testing.T, router *httprouter.Router, content string) *httptest.ResponseRecorder {
 	rr := httptest.NewRecorder()
 
 	request, err := http.NewRequest("POST", "/cache", strings.NewReader(content))
 	if err != nil {
 		t.Fatalf("Failed to create a POST request: %v", err)
-		return "", rr
+		return rr
 	}
-
 	router.ServeHTTP(rr, request)
-	uuid := ""
-	if rr.Code == http.StatusOK {
-		uuid = parseMockUUID(t, rr.Body.String())
-	}
-	return uuid, rr
+
+	return rr
 }
 
 func benchmarkPutHandler(b *testing.B, testCase string) {
@@ -1108,4 +1140,23 @@ func (b *deadlineExceedingBackend) Put(ctx context.Context, key string, value st
 
 func newDeadlineExceededBackend() *deadlineExceedingBackend {
 	return &deadlineExceedingBackend{}
+}
+
+type countingCallsBackend struct {
+	GetCalls int
+	PutCalls int
+}
+
+func (b *countingCallsBackend) Get(ctx context.Context, key string) (string, error) {
+	b.GetCalls++
+	return "", nil
+}
+
+func (b *countingCallsBackend) Put(ctx context.Context, key string, value string, ttlSeconds int) error {
+	b.PutCalls++
+	return nil
+}
+
+func newCountingCallsBackend() *countingCallsBackend {
+	return &countingCallsBackend{}
 }


### PR DESCRIPTION
`parsePutObject()` returns an error, but those error messages were getting ignored because we were not exiting the  `put(...)` function immediately after the error check.