### PR TITLE
Set default values for max_write_retries and max_read_retries

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,10 +53,8 @@ func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("backend.aerospike.user", "")
 	v.SetDefault("backend.aerospike.password", "")
 	v.SetDefault("backend.aerospike.default_ttl_seconds", 0)
-
 	v.SetDefault("backend.aerospike.max_read_retries", 2)
 	v.SetDefault("backend.aerospike.max_write_retries", 0)
-
 	v.SetDefault("backend.cassandra.hosts", "")
 	v.SetDefault("backend.cassandra.keyspace", "")
 	v.SetDefault("backend.cassandra.default_ttl_seconds", utils.CASSANDRA_DEFAULT_TTL_SECONDS)

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,10 @@ func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("backend.aerospike.user", "")
 	v.SetDefault("backend.aerospike.password", "")
 	v.SetDefault("backend.aerospike.default_ttl_seconds", 0)
+
+	v.SetDefault("backend.aerospike.max_read_retries", 2)
+	v.SetDefault("backend.aerospike.max_write_retries", 0)
+
 	v.SetDefault("backend.cassandra.hosts", "")
 	v.SetDefault("backend.cassandra.keyspace", "")
 	v.SetDefault("backend.cassandra.default_ttl_seconds", utils.CASSANDRA_DEFAULT_TTL_SECONDS)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1195,7 +1195,8 @@ func getExpectedDefaultConfig() Configuration {
 				Hosts: []string{},
 			},
 			Aerospike: Aerospike{
-				Hosts: []string{},
+				Hosts:          []string{},
+				MaxReadRetries: 2,
 			},
 			Cassandra: Cassandra{
 				DefaultTTL: utils.CASSANDRA_DEFAULT_TTL_SECONDS,
@@ -1244,13 +1245,14 @@ func getExpectedFullConfigForTestFile() Configuration {
 		Backend: Backend{
 			Type: BackendMemory,
 			Aerospike: Aerospike{
-				DefaultTTL: 3600,
-				Host:       "aerospike.prebid.com",
-				Hosts:      []string{"aerospike2.prebid.com", "aerospike3.prebid.com"},
-				Port:       3000,
-				Namespace:  "whatever",
-				User:       "foo",
-				Password:   "bar",
+				DefaultTTL:     3600,
+				Host:           "aerospike.prebid.com",
+				Hosts:          []string{"aerospike2.prebid.com", "aerospike3.prebid.com"},
+				Port:           3000,
+				Namespace:      "whatever",
+				User:           "foo",
+				Password:       "bar",
+				MaxReadRetries: 2,
 			},
 			Cassandra: Cassandra{
 				Hosts:      "127.0.0.1",


### PR DESCRIPTION
Forgot to set Max write and read retry default values so Viper reads the environment variable version of them