### PR TITLE
Update Aerospike client version to 6.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/prebid/prebid-cache
 go 1.16
 
 require (
-	github.com/aerospike/aerospike-client-go/v6 v6.2.1
+	github.com/aerospike/aerospike-client-go/v6 v6.7.0
 	github.com/bitly/go-hostpool v0.1.0 // indirect
 	github.com/didip/tollbooth/v6 v6.1.2
 	github.com/go-redis/redis/v8 v8.11.5

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/aerospike/aerospike-client-go/v6 v6.2.1 h1:GrLyJfWBokWw2AZoxnmaqAAQ3IdQqh5lD0M4gU5ytfM=
-github.com/aerospike/aerospike-client-go/v6 v6.2.1/go.mod h1:Tv2Y0WY69sqxy94/XSNNkNjMyW6WKyhwZIztHVBxrhw=
+github.com/aerospike/aerospike-client-go/v6 v6.7.0 h1:La2669CfR3VgwGtgqeIB1U6EUxQOWyFoyQPM/WTM8ws=
+github.com/aerospike/aerospike-client-go/v6 v6.7.0/go.mod h1:Do5/flmgSo2X32YLGAYd6o5e/U2gOSpgEhrIGyOS3UI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
Aerospike Go client [v6.4.0](https://github.com/aerospike/aerospike-client-go/releases/tag/v6.4.0) fixes major bugs related to connections
```
We recommend you update to this version ASAP. A bug might occur when a client performing a scan hits a "Partition
Unavailable" during an unstable cluster (in both high availability (AP) and strong consistency (CP) modes). Previous versions
of the client aborted the scan and put the connection back into the pool, which might cause unprocessed results to be sent
to a different transaction (of the same client), possibly resulting in incorrect application behavior. This has been fixed by Go
Client v5.10.0 and v6.4.0.
```