### PR TITLE
Workflow to create issue in pbc-java

### DIFF
--- a/.github/workflows/cross-repo-issue.yml
+++ b/.github/workflows/cross-repo-issue.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [closed]
     branches:
-      - "main"
+      - "master"
 
 jobs:
   cross-repo:

--- a/.github/workflows/cross-repo-issue.yml
+++ b/.github/workflows/cross-repo-issue.yml
@@ -10,15 +10,19 @@ jobs:
   cross-repo:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.XREPO_APP_ID }}
+          private_key: ${{ secrets.XREPO_PEM }}
       - name: create issue in other repo
         if: "!contains(github.event.pull_request.labels.*.name, 'do not port') && github.event.pull_request.merged"
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          curl -X "POST" "https://api.github.com/repos/prebid/prebid-cache-java/issues?state=all" \
-             -H "Cookie: logged_in=no" \
-             -u ${{ secrets.CROSSREPO_TOKEN }} \
-             -H "Content-Type: text/plain; charset=utf-8" \
-             -d $'{
-               "title": "New PR in PBC-Go: ${{ github.event.pull_request.title }}",
-               "body": "A PR was merged over in PBC-Go\\n\\n- [https://github.com/prebid/prebid-cache/pull/${{github.event.number}}](https://github.com/prebid/prebid-cache/pull/${{github.event.number}})\\n- timestamp: ${{ github.event.pull_request.merged_at}}",
-               "labels": [ "auto" ]
-            }'
+          echo -e "A PR was merged over on PBC-Go\n\n- [https://github.com/prebid/prebid-cache/pull/${{github.event.number}}](https://github.com/prebid/prebid-cache/pull/${{github.event.number}})\n- timestamp: ${{ github.event.pull_request.merged_at}}" > msg
+          export msg=$(cat msg)
+          gh issue create --repo prebid/prebid-cache-java --title "Port PR from PBC-Go: ${{ github.event.pull_request.title }}" \
+              --body "$msg" \
+              --label auto

--- a/.github/workflows/cross-repo-issue.yml
+++ b/.github/workflows/cross-repo-issue.yml
@@ -1,0 +1,24 @@
+name: Cross-repo Issue Creation
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - "main"
+
+jobs:
+  cross-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: create issue in other repo
+        if: "!contains(github.event.pull_request.labels.*.name, 'do not port') && github.event.pull_request.merged"
+        run: |
+          curl -X "POST" "https://api.github.com/repos/prebid/prebid-cache-java/issues?state=all" \
+             -H "Cookie: logged_in=no" \
+             -u ${{ secrets.CROSSREPO_TOKEN }} \
+             -H "Content-Type: text/plain; charset=utf-8" \
+             -d $'{
+               "title": "New PR in PBC-Go: ${{ github.event.pull_request.title }}",
+               "body": "A PR was merged over on test 1\\n\\n- [https://github.com/prebid/prebid-cache/pull/${{github.event.number}}](https://github.com/prebid/prebid-cache/pull/${{github.event.number}})\\n- timestamp: ${{ github.event.pull_request.merged_at}}",
+               "labels": [ "auto" ]
+            }'

--- a/.github/workflows/cross-repo-issue.yml
+++ b/.github/workflows/cross-repo-issue.yml
@@ -19,6 +19,6 @@ jobs:
              -H "Content-Type: text/plain; charset=utf-8" \
              -d $'{
                "title": "New PR in PBC-Go: ${{ github.event.pull_request.title }}",
-               "body": "A PR was merged over on test 1\\n\\n- [https://github.com/prebid/prebid-cache/pull/${{github.event.number}}](https://github.com/prebid/prebid-cache/pull/${{github.event.number}})\\n- timestamp: ${{ github.event.pull_request.merged_at}}",
+               "body": "A PR was merged over in PBC-Go\\n\\n- [https://github.com/prebid/prebid-cache/pull/${{github.event.number}}](https://github.com/prebid/prebid-cache/pull/${{github.event.number}})\\n- timestamp: ${{ github.event.pull_request.merged_at}}",
                "labels": [ "auto" ]
             }'


### PR DESCRIPTION
This is the process change we've been discussing, having github automatically open an issue in one repo when a PR is merged to its twin. Starting with PBC as a test, the idea would be to put versions of this workflow script in all 4 PBS/PBC repos

Conditions:
- merge close (not cancel close)
- label is not "do not port"

Here's a screenshot of what a resulting issue in PBC-Java would look like:
![Screen Shot 2022-12-22 at 3 55 33 PM](https://user-images.githubusercontent.com/4412838/209224254-5d62729e-426c-4d15-8102-67884b501733.png)

Obviously, you'll want to mentally replace "test1" with "PBC-Go" for this diagram.