### PR TITLE
Make Aerospike client connection queue size configurable

### DIFF
--- a/backends/aerospike.go
+++ b/backends/aerospike.go
@@ -68,6 +68,11 @@ func NewAerospikeBackend(cfg config.Aerospike, metrics *metrics.Metrics) *Aerosp
 		clientPolicy.IdleTimeout = time.Duration(cfg.ConnIdleTimeoutSecs) * time.Second
 	}
 
+	// If set, specify the size of the Connection Queue cache per node.
+	if cfg.ConnQueueSize > 0 {
+		clientPolicy.ConnectionQueueSize = cfg.ConnQueueSize
+	}
+
 	if len(cfg.Host) > 1 {
 		hosts = append(hosts, as.NewHost(cfg.Host, cfg.Port))
 		log.Info("config.backend.aerospike.host is being deprecated in favor of config.backend.aerospike.hosts")

--- a/backends/aerospike.go
+++ b/backends/aerospike.go
@@ -68,7 +68,8 @@ func NewAerospikeBackend(cfg config.Aerospike, metrics *metrics.Metrics) *Aerosp
 		clientPolicy.IdleTimeout = time.Duration(cfg.ConnIdleTimeoutSecs) * time.Second
 	}
 
-	// If set, specify the size of the Connection Queue cache per node.
+	// Aerospike's default connection queue size per node is 256.
+	// If cfg.ConnQueueSize is greater than zero, it will override the default.
 	if cfg.ConnQueueSize > 0 {
 		clientPolicy.ConnectionQueueSize = cfg.ConnQueueSize
 	}

--- a/config/backends.go
+++ b/config/backends.go
@@ -60,6 +60,8 @@ type Aerospike struct {
 	// tries to use it. If set to a value less than or equal to 0, Aerospike
 	// Client's default value will be used which is 55 seconds.
 	ConnIdleTimeoutSecs int `mapstructure:"connection_idle_timeout_seconds"`
+	// Specifies the size of the connection queue per node.
+	ConnQueueSize int `mapstructure:"connection_queue_size"`
 }
 
 func (cfg *Aerospike) validateAndLog() error {
@@ -97,6 +99,12 @@ func (cfg *Aerospike) validateAndLog() error {
 		cfg.MaxWriteRetries = 0
 	} else if cfg.MaxWriteRetries > 0 {
 		log.Infof("config.backend.aerospike.max_write_retries: %d.", cfg.MaxWriteRetries)
+	}
+
+	if cfg.ConnQueueSize > 0 {
+		log.Infof("config.backend.aerospike.connection_queue_size: %d", cfg.ConnQueueSize)
+	} else {
+		log.Infof("config.backend.aerospike.connection_queue_size value will default to 256")
 	}
 
 	return nil

--- a/config/backends_test.go
+++ b/config/backends_test.go
@@ -44,6 +44,7 @@ func TestAerospikeValidateAndLog(t *testing.T) {
 						{msg: "config.backend.aerospike.namespace: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.user: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.max_read_retries value will default to 2", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.connection_queue_size value will default to 256", lvl: logrus.InfoLevel},
 					},
 				},
 				{
@@ -62,6 +63,7 @@ func TestAerospikeValidateAndLog(t *testing.T) {
 						{msg: "config.backend.aerospike.namespace: prebid", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.user: prebid-user", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.max_read_retries value will default to 2", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.connection_queue_size value will default to 256", lvl: logrus.InfoLevel},
 					},
 				},
 				{
@@ -78,6 +80,7 @@ func TestAerospikeValidateAndLog(t *testing.T) {
 						{msg: "config.backend.aerospike.namespace: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.user: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.max_read_retries value will default to 2", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.connection_queue_size value will default to 256", lvl: logrus.InfoLevel},
 					},
 				},
 				{
@@ -95,6 +98,7 @@ func TestAerospikeValidateAndLog(t *testing.T) {
 						{msg: "config.backend.aerospike.namespace: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.user: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.max_read_retries value will default to 2", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.connection_queue_size value will default to 256", lvl: logrus.InfoLevel},
 					},
 				},
 				{
@@ -114,6 +118,7 @@ func TestAerospikeValidateAndLog(t *testing.T) {
 						{msg: "config.backend.aerospike.user: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.default_ttl_seconds: 3600. Note that this configuration option is being deprecated in favor of config.request_limits.max_ttl_seconds", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.max_read_retries value will default to 2", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.connection_queue_size value will default to 256", lvl: logrus.InfoLevel},
 					},
 				},
 				{
@@ -131,6 +136,7 @@ func TestAerospikeValidateAndLog(t *testing.T) {
 						{msg: "config.backend.aerospike.namespace: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.user: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.max_read_retries value will default to 2", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.connection_queue_size value will default to 256", lvl: logrus.InfoLevel},
 					},
 				},
 				{
@@ -148,10 +154,11 @@ func TestAerospikeValidateAndLog(t *testing.T) {
 						{msg: "config.backend.aerospike.namespace: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.user: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.max_read_retries: 3.", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.connection_queue_size value will default to 256", lvl: logrus.InfoLevel},
 					},
 				},
 				{
-					desc: "aerospike.max_write_retries invalid value. Default to 2 retries",
+					desc: "aerospike.max_write_retries invalid value. Default to 0 retries",
 					inCfg: Aerospike{
 						Host:            "foo.com",
 						Port:            8888,
@@ -166,6 +173,7 @@ func TestAerospikeValidateAndLog(t *testing.T) {
 						{msg: "config.backend.aerospike.namespace: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.user: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.max_write_retries value cannot be negative and will default to 0", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.connection_queue_size value will default to 256", lvl: logrus.InfoLevel},
 					},
 				},
 				{
@@ -184,6 +192,7 @@ func TestAerospikeValidateAndLog(t *testing.T) {
 						{msg: "config.backend.aerospike.namespace: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.user: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.max_write_retries: 1.", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.connection_queue_size value will default to 256", lvl: logrus.InfoLevel},
 					},
 				},
 				{
@@ -202,6 +211,43 @@ func TestAerospikeValidateAndLog(t *testing.T) {
 						{msg: "config.backend.aerospike.user: ", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.connection_idle_timeout_seconds: 1.", lvl: logrus.InfoLevel},
 						{msg: "config.backend.aerospike.max_read_retries value will default to 2", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.connection_queue_size value will default to 256", lvl: logrus.InfoLevel},
+					},
+				},
+				{
+					desc: "config.backend.aerospike.connection_queue_size invalid value found in config",
+					inCfg: Aerospike{
+						Host:          "foo.com",
+						Port:          8888,
+						ConnQueueSize: -1,
+					},
+					hasError: false,
+					logEntries: []logComponents{
+						{msg: "config.backend.aerospike.host: foo.com", lvl: logrus.InfoLevel},
+						{msg: fmt.Sprintf("config.backend.aerospike.hosts: %v", []string{}), lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.port: 8888", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.namespace: ", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.user: ", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.max_read_retries value will default to 2", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.connection_queue_size value will default to 256", lvl: logrus.InfoLevel},
+					},
+				},
+				{
+					desc: "config.backend.aerospike.connection_queue_size valid value found in config",
+					inCfg: Aerospike{
+						Host:          "foo.com",
+						Port:          8888,
+						ConnQueueSize: 64,
+					},
+					hasError: false,
+					logEntries: []logComponents{
+						{msg: "config.backend.aerospike.host: foo.com", lvl: logrus.InfoLevel},
+						{msg: fmt.Sprintf("config.backend.aerospike.hosts: %v", []string{}), lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.port: 8888", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.namespace: ", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.user: ", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.max_read_retries value will default to 2", lvl: logrus.InfoLevel},
+						{msg: "config.backend.aerospike.connection_queue_size: 64", lvl: logrus.InfoLevel},
 					},
 				},
 			},

--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,7 @@ func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("backend.aerospike.max_read_retries", 2)
 	v.SetDefault("backend.aerospike.max_write_retries", 0)
 	v.SetDefault("backend.aerospike.connection_idle_timeout_seconds", 0)
+	v.SetDefault("backend.aerospike.connection_queue_size", 0)
 	v.SetDefault("backend.cassandra.hosts", "")
 	v.SetDefault("backend.cassandra.keyspace", "")
 	v.SetDefault("backend.cassandra.default_ttl_seconds", utils.CASSANDRA_DEFAULT_TTL_SECONDS)


### PR DESCRIPTION
By default the Aerospike client starts with a connection queue cache size of 256 per node. This pull request implements `ConnQueueSize` that lets the host set this value from the configuration file or an environment variable.

**yaml**
```yaml
backend:
  type: "memory" # Can also be "aerospike", "cassandra", "memcache" or "redis"
  aerospike:
    host: "aerospike.prebid.com"
    port: 3000
    namespace: "whatever"
    connection_queue_size: 64
```

**json**
```json
{
  "port": 2424,
  "admin_port": 2525,
  "log": {
    "level": "info"
  },
  "backend": {
    "type": "aerospike",
    "aerospike": {
      "host": "aerospike.prebid.com",
      "port": 3000,
      "namespace": "whatever",
      "connection_queue_size": 64
    }
  }
}
```

**Environment variable**
```bash
PBC_BACKEND_TYPE="aerospike"
PBC_BACKEND_AEROSPIKE_HOST="aerospike.prebid.com"
PBC_BACKEND_AEROSPIKE_PORT=3000
PBC_BACKEND_AEROSPIKE_NAMESPACE="whatever"
PBC_BACKEND_AEROSPIKE_CONNECTION_QUEUE_SIZE=64
```