### PR TITLE
Push for the use of "aerospike.hosts" in config file

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,7 +13,7 @@ request_limits:
 backend:
   type: "memory" # Can also be "aerospike", "cassandra", "memcache" or "redis"
   aerospike:
-    host: "aerospike.prebid.com"
+    hosts: [ "aerospike.prebid.com" ]
     port: 3000
     namespace: "whatever"
   cassandra:


### PR DESCRIPTION
When configuring the Aerospike backend, `config.backend.aerospike.host` is being deprecated in favor of `config.backend.aerospike.hosts`, an array of URLs. This pull requests tweaks the default configuration file `config.yaml` to encourage the use of `config.backend.aerospike.hosts` over `config.backend.aerospike.host`.

Created as an answer to the concern raised in issue #128 