### PR TITLE
Update to Ubuntu 20.04

### DIFF
--- a/.github/workflows/validate-merge.yml
+++ b/.github/workflows/validate-merge.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate-merge:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     
     steps:
     - name: Install Go

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.18.x, 1.19.x]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     
     steps:
     - name: Install Go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 AS build
+FROM ubuntu:20.04 AS build
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y wget
@@ -22,7 +22,7 @@ ARG TEST="true"
 RUN if [ "$TEST" != "false" ]; then ./validate.sh ; fi
 RUN go build -mod=vendor -ldflags "-X github.com/prebid/prebid-cache/version.Ver=`git describe --tags` -X github.com/prebid/prebid-cache/version.Rev=`git rev-parse HEAD`" .
 
-FROM ubuntu:18.04 AS release
+FROM ubuntu:20.04 AS release
 LABEL maintainer="hans.hjort@xandr.com" 
 RUN apt-get update && \
     apt-get install --assume-yes apt-utils && \


### PR DESCRIPTION
Ubuntu 18.04 is reaching End of Standard Support in May 2023. This pull request updates Github actions files and the Dockerfile to make use of the next Long Term Support (LTS) release: Ubuntu 20.04