### PR TITLE
Update actions to use newer version to support node.js 16

### DIFF
--- a/.github/workflows/validate-merge.yml
+++ b/.github/workflows/validate-merge.yml
@@ -10,12 +10,12 @@ jobs:
     
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: 1.19.5
 
     - name: Checkout Merged Branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Validate
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,12 +15,12 @@ jobs:
     
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout Branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # Resolves to empty string for push events and falls back to HEAD.
         # See: https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit


### PR DESCRIPTION
Github has ended support for node 12 and has recommended plugin maintainers to use node 16 before summer 2023. Refer [here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for more details. Public repos like [prebid server](https://github.com/prebid/prebid-server) and [prebid cache](https://github.com/prebid/prebid-cache) make use of community plugins in actions. As part of this PR, we are updating actions to use newer version of plugin which has support for node 16.