### PR TITLE
Update tibdex/github-app-token version to support node.js16

### DIFF
--- a/.github/workflows/cross-repo-issue.yml
+++ b/.github/workflows/cross-repo-issue.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@v1.8.0
         with:
           app_id: ${{ secrets.XREPO_APP_ID }}
           private_key: ${{ secrets.XREPO_PEM }}

--- a/.github/workflows/issue_prioritization.yml
+++ b/.github/workflows/issue_prioritization.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@36464acb844fc53b9b8b2401da68844f6b05ebb0
+        uses: tibdex/github-app-token@v1.8.0
         with:
           app_id: ${{ secrets.PBS_PROJECT_APP_ID }}
           private_key: ${{ secrets.PBS_PROJECT_APP_PEM }}


### PR DESCRIPTION
Github has ended support for node 12 and has recommended plugin maintainers to use node 16 before summer 2023. Refer [here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for more details. Public repos like [prebid server](https://github.com/prebid/prebid-server) and [prebid cache](https://github.com/prebid/prebid-cache) make use of community plugins in actions. As part of this PR, we are updating actions to use newer version of plugin which has support for node 16.