### PR TITLE
Update docker/login-action version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
           docker build --build-arg DEPLOY_VERSION=${{ needs.publish-tag.outputs.releaseTag }} -t docker.io/prebid/prebid-cache:${{ needs.publish-tag.outputs.releaseTag }} .
       - name: Login to docker Hub
         if: contains(inputs.debug, 'false')
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION

- Release workflow yml uses docker/login-action v1. This version runs on node 12. 
- Github actions has announce to deprecate node 12 and has recommended to use node 16 (https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12). 
- Latest version of docker/login-action runs on node 16. Therefore use latest version of docker/login-action.
- Testing: Similar changes are done for prebid-server repo. Details are [here](https://github.com/prebid/prebid-server/pull/2769#issue-1705482205).