### PR TITLE
Refactor NewAerospikeBackend function

### DIFF
--- a/backends/aerospike.go
+++ b/backends/aerospike.go
@@ -95,14 +95,12 @@ func generateAerospikeClientPolicy(cfg config.Aerospike) *as.ClientPolicy {
 	clientPolicy.User = cfg.User
 	clientPolicy.Password = cfg.Password
 
-	// Aerospike's connection idle deadline default is 55 seconds. If greater than zero, this
-	// value will override
+	// Connection idle timeout default is 55 seconds
 	if cfg.ConnIdleTimeoutSecs > 0 {
 		clientPolicy.IdleTimeout = time.Duration(cfg.ConnIdleTimeoutSecs) * time.Second
 	}
 
-	// Aerospike's default connection queue size per node is 256.
-	// If cfg.ConnQueueSize is greater than zero, it will override the default.
+	// Default connection queue size per node is 256
 	if cfg.ConnQueueSize > 0 {
 		clientPolicy.ConnectionQueueSize = cfg.ConnQueueSize
 	}

--- a/backends/aerospike_test.go
+++ b/backends/aerospike_test.go
@@ -221,7 +221,8 @@ func TestNewAerospikeBackend(t *testing.T) {
 		expectedLogEntryLevels []logrus.Level
 	}{
 		{
-			desc: "Unable to connect to URLs in Hosts list.",
+			// Unable to connect to host in Hosts list. Expect fatal level log entry
+			desc: "Hosts_slice_and_port",
 			inCfg: config.Aerospike{
 				Hosts: []string{"fakeUrl"},
 				Port:  8888,
@@ -229,7 +230,9 @@ func TestNewAerospikeBackend(t *testing.T) {
 			expectedLogEntryLevels: []logrus.Level{logrus.FatalLevel},
 		},
 		{
-			desc: "Unable to connect to URL in Host field",
+			// Unable to connect to URL in Host field. Expect fatal level log entry and
+			// an info level log entry because the Host string is deprecated
+			desc: "Host_string_and_port",
 			inCfg: config.Aerospike{
 				Host: "fakeUrl",
 				Port: 8888,


### PR DESCRIPTION
Issue #162 documents a `NewAerospikeBackend` unit test that fails. When looking into the issue documented in issue #162 the need to refactor `NewAerospikeBackend`, for more accurate testing and better readability, was evident. This pull request makes such modifications.