### PR TITLE
Config max request header size

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,7 @@ func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("request_limits.max_size_bytes", utils.REQUEST_MAX_SIZE_BYTES)
 	v.SetDefault("request_limits.max_num_values", utils.REQUEST_MAX_NUM_VALUES)
 	v.SetDefault("request_limits.max_ttl_seconds", utils.REQUEST_MAX_TTL_SECONDS)
+	v.SetDefault("request_limits.max_header_size_bytes", 0)
 	v.SetDefault("routes.allow_public_write", true)
 }
 
@@ -179,6 +180,7 @@ type RequestLimits struct {
 	MaxNumValues     int  `mapstructure:"max_num_values"`
 	MaxTTLSeconds    int  `mapstructure:"max_ttl_seconds"`
 	AllowSettingKeys bool `mapstructure:"allow_setting_keys"`
+	MaxHeaderSize    int  `mapstructure:"max_header_size_bytes"`
 }
 
 func (cfg *RequestLimits) validateAndLog() {
@@ -200,6 +202,12 @@ func (cfg *RequestLimits) validateAndLog() {
 		log.Infof("config.request_limits.max_num_values: %d", cfg.MaxNumValues)
 	} else {
 		log.Fatalf("invalid config.request_limits.max_num_values: %d. Value cannot be negative.", cfg.MaxNumValues)
+	}
+
+	if cfg.MaxHeaderSize >= 0 {
+		log.Infof("config.request_limits.max_header_size_bytes: %d", cfg.MaxHeaderSize)
+	} else {
+		log.Fatalf("invalid config.request_limits.max_header_size_bytes: %d. Value cannot be negative.", cfg.MaxHeaderSize)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1078,6 +1078,7 @@ func TestConfigurationValidateAndLog(t *testing.T) {
 		{msg: fmt.Sprintf("config.request_limits.max_ttl_seconds: %d", expectedConfig.RequestLimits.MaxTTLSeconds), lvl: logrus.InfoLevel},
 		{msg: fmt.Sprintf("config.request_limits.max_size_bytes: %d", expectedConfig.RequestLimits.MaxSize), lvl: logrus.InfoLevel},
 		{msg: fmt.Sprintf("config.request_limits.max_num_values: %d", expectedConfig.RequestLimits.MaxNumValues), lvl: logrus.InfoLevel},
+		{msg: fmt.Sprintf("config.request_limits.max_header_size_bytes: %d", expectedConfig.RequestLimits.MaxHeaderSize), lvl: logrus.InfoLevel},
 		{msg: fmt.Sprintf("config.backend.type: %s", expectedConfig.Backend.Type), lvl: logrus.InfoLevel},
 		{msg: fmt.Sprintf("config.compression.type: %s", expectedConfig.Compression.Type), lvl: logrus.InfoLevel},
 		{msg: fmt.Sprintf("Prebid Cache will run without metrics"), lvl: logrus.InfoLevel},
@@ -1244,6 +1245,7 @@ func getExpectedFullConfigForTestFile() Configuration {
 			MaxNumValues:     10,
 			MaxTTLSeconds:    5000,
 			AllowSettingKeys: true,
+			MaxHeaderSize:    16384, //16KiB
 		},
 		Backend: Backend{
 			Type: BackendMemory,

--- a/config/configtest/sample_full_config.yaml
+++ b/config/configtest/sample_full_config.yaml
@@ -11,6 +11,7 @@ request_limits:
   max_num_values: 10
   max_ttl_seconds: 5000
   allow_setting_keys: true
+  max_header_size_bytes: 16384
 backend:
   type: "memory"
   aerospike:

--- a/server/server.go
+++ b/server/server.go
@@ -74,20 +74,36 @@ func Listen(cfg config.Configuration, publicHandler http.Handler, adminHandler h
 	return
 }
 
+// newAdminServer returns an http.Server with the configured with the AdminPort and
+// RequestLimits.MaxHeaderBytes values specified in Prebid Cache's config files or
+// environment variables. If RequestLimits.MaxHeaderBytes is zero or non-specified,
+// the http library sets server.MaxHeaderBytes to the value of http.DefaultMaxHeaderBytes
 func newAdminServer(cfg config.Configuration, handler http.Handler) *http.Server {
-	return &http.Server{
+	server := &http.Server{
 		Addr:    ":" + strconv.Itoa(cfg.AdminPort),
 		Handler: handler,
 	}
+	if cfg.RequestLimits.MaxHeaderSize > 0 {
+		server.MaxHeaderBytes = cfg.RequestLimits.MaxHeaderSize
+	}
+	return server
 }
 
+// newMainServer returns an http.Server with the configured with the Port and
+// RequestLimits.MaxHeaderBytes values specified in Prebid Cache's config files
+// or environment variables. If RequestLimits.MaxHeaderBytes is zero or non-specified,
+// 1 MB, which is the value of the http library's DefaultMaxHeaderBytes, is set instead.
 func newMainServer(cfg config.Configuration, handler http.Handler) *http.Server {
-	return &http.Server{
+	server := &http.Server{
 		Addr:         ":" + strconv.Itoa(cfg.Port),
 		Handler:      handler,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,
 	}
+	if cfg.RequestLimits.MaxHeaderSize > 0 {
+		server.MaxHeaderBytes = cfg.RequestLimits.MaxHeaderSize
+	}
+	return server
 }
 
 func runServer(server *http.Server, name string, listener net.Listener) {


### PR DESCRIPTION
Implements #168 by adding a config field to specify the http request max header size in bytes.